### PR TITLE
2.x cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,31 @@ class CreateBlogRequest extends FormRequest
 
 ### Additional helpers
 
+#### Defined rule sets
+
+The `RuleSet` class contains methods to define and reuse rule sets across the project.
+
+To define a rule set call `RuleSet::define` in your app service provider's boot method.
+
+```php
+    public function boot(): void
+    {
+        RuleSet::define('existing_email', RuleSet::create()->email()->exists('users'));
+    }
+```
+
+The defined set can then be used in rules using `RuleSet::useDefined`.
+
+```php
+    public function rules(): array
+    {
+        return [
+            'to' => RuleSet::useDefined('existing_email')->required(),
+            'bcc' => RuleSet::useDefined('existing_email'),
+        ];
+    }
+```
+
 #### requiredIfAll
 
 Accepts multiple `RequiredIf` rules and only marks as required if all return true.

--- a/src/Rule.php
+++ b/src/Rule.php
@@ -823,7 +823,7 @@ class Rule extends LaravelRule
         return 'uuid';
     }
 
-    private static function convertDateForRule(
+    protected static function convertDateForRule(
         string|DateTimeInterface $date,
         string $format = DateTimeInterface::RFC3339
     ): string {
@@ -834,7 +834,7 @@ class Rule extends LaravelRule
         }
     }
 
-    private static function getRuleResults(array $rules): Collection
+    protected static function getRuleResults(array $rules): Collection
     {
         return collect($rules)
             ->map(

--- a/src/Rule.php
+++ b/src/Rule.php
@@ -269,7 +269,7 @@ class Rule extends LaravelRule
      *
      * @link https://laravel.com/docs/9.x/validation#rule-distinct
      */
-    public static function distinct(bool $strict = false, $ignoreCase = false): string
+    public static function distinct(bool $strict = false, bool $ignoreCase = false): string
     {
         if ($ignoreCase) {
             return 'distinct:ignore_case';

--- a/src/RuleSet.php
+++ b/src/RuleSet.php
@@ -341,7 +341,7 @@ class RuleSet implements Arrayable
      *
      * @link https://laravel.com/docs/9.x/validation#rule-distinct
      */
-    public function distinct(bool $strict = false, $ignoreCase = false): self
+    public function distinct(bool $strict = false, bool $ignoreCase = false): self
     {
         return $this->rule(Rule::distinct($strict, $ignoreCase));
     }

--- a/src/RuleSet.php
+++ b/src/RuleSet.php
@@ -10,7 +10,7 @@ use Illuminate\Validation\Rules\RequiredIf;
 
 class RuleSet implements Arrayable
 {
-    public function __construct(private array $rules = [])
+    public function __construct(protected array $rules = [])
     {
     }
 
@@ -956,7 +956,7 @@ class RuleSet implements Arrayable
         return $this->rule(Rule::uuid());
     }
 
-    private static function getDefinedRuleSets(): Contracts\DefinedRuleSets
+    protected static function getDefinedRuleSets(): Contracts\DefinedRuleSets
     {
         return resolve(Contracts\DefinedRuleSets::class);
     }


### PR DESCRIPTION
Some clean up before a 2.x release.

----

We may want to address [this](https://phpstan.org/blog/solving-phpstan-error-unsafe-usage-of-new-static) if we want to include PhpStan at some point, I am unsure which fix is the best approach (or if it is even something worth fixing).  There is only one other error in a default Larastan setup related to passing in a non-rule interface to the rule method, but I think that is safe to ignore since Laravel doesn't use the interface on their base rule classes.