### PR TITLE
Rule class conflict fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@ class CreateBlogRequest extends FormRequest
 
 ### Rule
 
-The `Rule` class is an extension of the Laravel `\Illuminate\Validation\Rule` class to expose the rest of the built-in
-rules via static methods.
+The `Rule` class provides the same methods as the Laravel `\Illuminate\Validation\Rule` class, with the rest of the
+built-in rules exposed via static methods.
 
 #### Basic usage
 

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "minimum-stability": "stable",
     "require": {
         "php": "^8.0",
-        "laravel/framework": "^9.0.2"
+        "laravel/framework": "^9.6"
     },
     "require-dev": {
         "ext-json": "*",

--- a/src/Rule.php
+++ b/src/Rule.php
@@ -323,7 +323,7 @@ class Rule extends LaravelRule
      *
      * @link https://laravel.com/docs/9.x/validation#rule-exclude-if
      */
-    public static function excludeIf(string $anotherField, ?string $value): string
+    public static function excludeIfValue(string $anotherField, ?string $value): string
     {
         return sprintf('exclude_if:%s,%s', $anotherField, $value ?? 'null');
     }
@@ -600,7 +600,7 @@ class Rule extends LaravelRule
      *
      * @link https://laravel.com/docs/9.x/validation#rule-prohibited-if
      */
-    public static function prohibitedIf(string $anotherField, string ...$value): string
+    public static function prohibitedIfValue(string $anotherField, string ...$value): string
     {
         return sprintf('prohibited_if:%s,%s', $anotherField, implode(',', $value));
     }

--- a/src/Rule.php
+++ b/src/Rule.php
@@ -5,11 +5,19 @@ declare(strict_types=1);
 namespace Sourcetoad\RuleHelper;
 
 use DateTimeInterface;
+use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Support\Collection;
 use Illuminate\Validation\Rule as LaravelRule;
+use Illuminate\Validation\Rules\Dimensions;
+use Illuminate\Validation\Rules\ExcludeIf;
+use Illuminate\Validation\Rules\Exists;
+use Illuminate\Validation\Rules\In;
+use Illuminate\Validation\Rules\NotIn;
+use Illuminate\Validation\Rules\ProhibitedIf;
 use Illuminate\Validation\Rules\RequiredIf;
+use Illuminate\Validation\Rules\Unique;
 
-class Rule extends LaravelRule
+class Rule
 {
     /**
      * The field under validation must be "yes", "on", 1, or true. This is useful for validating "Terms of Service"
@@ -265,6 +273,22 @@ class Rule extends LaravelRule
     }
 
     /**
+     * The file under validation must be an image meeting the dimension constraints as specified by the rule's
+     * parameters.
+     *
+     * Available constraints are: *min_width*, *max_width*, *min_height*, *max_height*, *width*, *height*, *ratio*.
+     *
+     * A ratio constraint should be represented as width divided by height. This can be specified either by a fraction
+     * like *3/2* or a float like *1.5*.
+     *
+     * @link https://laravel.com/docs/9.x/validation#rule-dimensions
+     */
+    public static function dimensions(array $constraints = []): Dimensions
+    {
+        return LaravelRule::dimensions($constraints);
+    }
+
+    /**
      * When validating arrays, the field under validation must not have any duplicate values.
      *
      * @link https://laravel.com/docs/9.x/validation#rule-distinct
@@ -318,7 +342,19 @@ class Rule extends LaravelRule
     }
 
     /**
-     * The field under validation will be excluded from the request data returned by the *validate* and *validated*.
+     * The field under validation will be excluded from the request data returned by the *validate* and *validated*
+     * methods if a true boolean is passed in or the passed in closure returns true.
+     *
+     * @link https://laravel.com/docs/9.x/validation#rule-exclude-if
+     * @param callable|bool $callback
+     */
+    public static function excludeIf(mixed $callback): ExcludeIf
+    {
+        return LaravelRule::excludeIf($callback);
+    }
+
+    /**
+     * The field under validation will be excluded from the request data returned by the *validate* and *validated*
      * methods if the *anotherField* field is equal to *value*.
      *
      * @link https://laravel.com/docs/9.x/validation#rule-exclude-if
@@ -348,6 +384,18 @@ class Rule extends LaravelRule
     public static function excludeWithout(string $anotherField): string
     {
         return 'exclude_without:'.$anotherField;
+    }
+
+    /**
+     * The field under validation must exist in a given database table. If the *column* option is not specified, the
+     * field name will be used. Instead of specifying the table name directly, you may specify the Eloquent model class
+     * name.
+     *
+     * @link https://laravel.com/docs/9.x/validation#rule-exists
+     */
+    public static function exists(string $table, string $column = 'NULL'): Exists
+    {
+        return LaravelRule::exists($table, $column);
     }
 
     /**
@@ -398,6 +446,19 @@ class Rule extends LaravelRule
     public static function image(): string
     {
         return 'image';
+    }
+
+    /**
+     * The field under validation must be included in the given list of values.
+     *
+     * When the *in* rule is combined with the *array* rule, each value in the input array must be present within the
+     * list of values provided to the *in* rule.
+     *
+     * @link https://laravel.com/docs/9.x/validation#rule-in
+     */
+    public static function in(Arrayable|array|string $values): In
+    {
+        return LaravelRule::in($values);
     }
 
     /**
@@ -545,6 +606,16 @@ class Rule extends LaravelRule
     }
 
     /**
+     * The field under validation must not be included in the given list of values.
+     *
+     * @link https://laravel.com/docs/9.x/validation#rule-not-in
+     */
+    public static function notIn(Arrayable|array|string $values): NotIn
+    {
+        return LaravelRule::notIn($values);
+    }
+
+    /**
      * The field under validation must not match the given regular expression.
      *
      * @link https://laravel.com/docs/9.x/validation#rule-not-regex
@@ -593,6 +664,18 @@ class Rule extends LaravelRule
     public static function prohibited(): string
     {
         return 'prohibited';
+    }
+
+    /**
+     * The field under validation must be empty or not present in the input data if a true boolean is passed in or the
+     * passed in closure returns true.
+     *
+     * @link https://laravel.com/docs/9.x/validation#rule-prohibited-if
+     * @param callable|bool $callback
+     */
+    public static function prohibitedIf(mixed $callback): ProhibitedIf
+    {
+        return LaravelRule::prohibitedIf($callback);
     }
 
     /**
@@ -653,6 +736,18 @@ class Rule extends LaravelRule
     public static function requiredArrayKeys(string ...$key): string
     {
         return sprintf('required_array_keys:%s', implode(',', $key));
+    }
+
+    /**
+     * The field under validation must be present in the input data if a true boolean is passed in or the passed in
+     * closure returns true.
+     *
+     * @link https://laravel.com/docs/9.x/validation#rule-required-if
+     * @param callable|bool $callback
+     */
+    public static function requiredIf(mixed $callback): RequiredIf
+    {
+        return LaravelRule::requiredIf($callback);
     }
 
     /**
@@ -801,6 +896,18 @@ class Rule extends LaravelRule
     public static function timezone(): string
     {
         return 'timezone';
+    }
+
+    /**
+     * The field under validation must not exist within the given database table. If the *column* option is not
+     * specified, the field name will be used. Instead of specifying the table name directly, you may specify the
+     * Eloquent model class name.
+     *
+     * @link https://laravel.com/docs/9.x/validation#rule-unique
+     */
+    public static function unique(string $table, string $column = 'NULL'): Unique
+    {
+        return LaravelRule::unique($table, $column);
     }
 
     /**

--- a/src/Rule.php
+++ b/src/Rule.php
@@ -8,6 +8,7 @@ use DateTimeInterface;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Support\Collection;
 use Illuminate\Validation\ConditionalRules;
+use Illuminate\Validation\NestedRules;
 use Illuminate\Validation\Rule as LaravelRule;
 use Illuminate\Validation\Rules\Dimensions;
 use Illuminate\Validation\Rules\ExcludeIf;
@@ -428,6 +429,32 @@ class Rule
     public static function filled(): string
     {
         return 'filled';
+    }
+
+    /**
+     * Create a new nested rule set.
+     *
+     * @link https://laravel.com/docs/9.x/validation#accessing-nested-array-data
+     */
+    public static function forEach(callable $callback): NestedRules
+    {
+        return new NestedRules(function ($value, $attribute, $data = null) use ($callback) {
+            $rules = $callback($value, $attribute, $data);
+
+            if ($rules instanceof RuleSet) {
+                $rules = $rules->toArray();
+            }
+
+            if (is_array($rules)) {
+                foreach ($rules as $index => $ruleSet) {
+                    if ($ruleSet instanceof RuleSet) {
+                        $rules[$index] = $ruleSet->toArray();
+                    }
+                }
+            }
+
+            return $rules;
+        });
     }
 
     /**

--- a/src/Rule.php
+++ b/src/Rule.php
@@ -7,6 +7,7 @@ namespace Sourcetoad\RuleHelper;
 use DateTimeInterface;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Support\Collection;
+use Illuminate\Validation\ConditionalRules;
 use Illuminate\Validation\Rule as LaravelRule;
 use Illuminate\Validation\Rules\Dimensions;
 use Illuminate\Validation\Rules\ExcludeIf;
@@ -939,6 +940,23 @@ class Rule
     public static function uuid(): string
     {
         return 'uuid';
+    }
+
+    /**
+     * Create a new conditional rule set.
+     */
+    public static function when(
+        mixed $condition,
+        array|string|RuleSet $rules,
+        array|string|RuleSet $defaultRules = []
+    ): ConditionalRules {
+        if ($rules instanceof RuleSet) {
+            $rules = $rules->toArray();
+        }
+        if ($defaultRules instanceof RuleSet) {
+            $defaultRules = $defaultRules->toArray();
+        }
+        return new ConditionalRules($condition, $rules, $defaultRules);
     }
 
     protected static function convertDateForRule(

--- a/src/Rule.php
+++ b/src/Rule.php
@@ -377,6 +377,17 @@ class Rule
 
     /**
      * The field under validation will be excluded from the request data returned by the *validate* and *validated*
+     * methods if the *anotherField* field is present.
+     *
+     * @link https://laravel.com/docs/9.x/validation#rule-exclude-with
+     */
+    public static function excludeWith(string $anotherField): string
+    {
+        return 'exclude_with:'.$anotherField;
+    }
+
+    /**
+     * The field under validation will be excluded from the request data returned by the *validate* and *validated*
      * methods if the *anotherField* field is not present.
      *
      * @link https://laravel.com/docs/9.x/validation#rule-exclude-without

--- a/src/RuleSet.php
+++ b/src/RuleSet.php
@@ -991,6 +991,14 @@ class RuleSet implements Arrayable
         return $this->rule(Rule::uuid());
     }
 
+    /**
+     * Create a new conditional rule set.
+     */
+    public function when(mixed $condition, array|string|RuleSet $rules, array|string|RuleSet $defaultRules = []): self
+    {
+        return $this->rule(Rule::when($condition, $rules, $defaultRules));
+    }
+
     protected static function getDefinedRuleSets(): Contracts\DefinedRuleSets
     {
         return resolve(Contracts\DefinedRuleSets::class);

--- a/src/RuleSet.php
+++ b/src/RuleSet.php
@@ -413,6 +413,17 @@ class RuleSet implements Arrayable
 
     /**
      * The field under validation will be excluded from the request data returned by the *validate* and *validated*
+     * methods if the *anotherField* field is present.
+     *
+     * @link https://laravel.com/docs/9.x/validation#rule-exclude-with
+     */
+    public function excludeWith(string $anotherField): self
+    {
+        return $this->rule(Rule::excludeWith($anotherField));
+    }
+
+    /**
+     * The field under validation will be excluded from the request data returned by the *validate* and *validated*
      * methods if the *anotherField* field is not present.
      *
      * @link https://laravel.com/docs/9.x/validation#rule-exclude-without

--- a/src/RuleSet.php
+++ b/src/RuleSet.php
@@ -383,9 +383,9 @@ class RuleSet implements Arrayable
      *
      * @link https://laravel.com/docs/9.x/validation#rule-exclude-if
      */
-    public function excludeIf(string $anotherField, ?string $value): self
+    public function excludeIfValue(string $anotherField, ?string $value): self
     {
-        return $this->rule(Rule::excludeIf($anotherField, $value));
+        return $this->rule(Rule::excludeIfValue($anotherField, $value));
     }
 
     /**
@@ -704,9 +704,9 @@ class RuleSet implements Arrayable
      *
      * @link https://laravel.com/docs/9.x/validation#rule-prohibited-if
      */
-    public function prohibitedIf(string $anotherField, string ...$value): self
+    public function prohibitedIfValue(string $anotherField, string ...$value): self
     {
-        return $this->rule(Rule::prohibitedIf($anotherField, ...$value));
+        return $this->rule(Rule::prohibitedIfValue($anotherField, ...$value));
     }
 
     /**

--- a/src/RuleSet.php
+++ b/src/RuleSet.php
@@ -475,6 +475,16 @@ class RuleSet implements Arrayable
     }
 
     /**
+     * Create a new nested rule set.
+     *
+     * @link https://laravel.com/docs/9.x/validation#accessing-nested-array-data
+     */
+    public function forEach(callable $callback): self
+    {
+        return $this->rule(Rule::forEach($callback));
+    }
+
+    /**
      * The field under validation must be greater than the given *field*.
      *
      * @link https://laravel.com/docs/9.x/validation#rule-gt

--- a/src/RuleSet.php
+++ b/src/RuleSet.php
@@ -378,6 +378,18 @@ class RuleSet implements Arrayable
     }
 
     /**
+     * The field under validation will be excluded from the request data returned by the *validate* and *validated*
+     * methods if a true boolean is passed in or the passed in closure returns true.
+     *
+     * @link https://laravel.com/docs/9.x/validation#rule-exclude-if
+     * @param callable|bool $callback
+     */
+    public function excludeIf(mixed $callback): self
+    {
+        return $this->rule(Rule::excludeIf($callback));
+    }
+
+    /**
      * The field under validation will be excluded from the request data returned by the *validate* and *validated*.
      * methods if the *anotherField* field is equal to *value*.
      *
@@ -697,6 +709,18 @@ class RuleSet implements Arrayable
     public function prohibited(): self
     {
         return $this->rule(Rule::prohibited());
+    }
+
+    /**
+     * The field under validation must be empty or not present in the input data if a true boolean is passed in or the
+     * passed in closure returns true.
+     *
+     * @link https://laravel.com/docs/9.x/validation#rule-prohibited-if
+     * @param callable|bool $callback
+     */
+    public function prohibitedIf(mixed $callback): self
+    {
+        return $this->rule(Rule::prohibitedIf($callback));
     }
 
     /**

--- a/tests/Unit/RuleTest.php
+++ b/tests/Unit/RuleTest.php
@@ -1145,23 +1145,23 @@ class RuleTest extends TestCase
                 ],
                 'fails' => true,
             ],
-            'prohibitedIf valid' => [
+            'prohibitedIfValue valid' => [
                 'data' => [
                     'field-a' => '',
                     'field-b' => 'b',
                 ],
                 'rules' => fn() => [
-                    'field-a' => RuleSet::create()->prohibitedIf('field-b', 'a', 'b', 'c'),
+                    'field-a' => RuleSet::create()->prohibitedIfValue('field-b', 'a', 'b', 'c'),
                 ],
                 'fails' => false,
             ],
-            'prohibitedIf invalid' => [
+            'prohibitedIfValue invalid' => [
                 'data' => [
                     'field-a' => 'a',
                     'field-b' => 'b',
                 ],
                 'rules' => fn() => [
-                    'field-a' => RuleSet::create()->prohibitedIf('field-b', 'a', 'b', 'c'),
+                    'field-a' => RuleSet::create()->prohibitedIfValue('field-b', 'a', 'b', 'c'),
                 ],
                 'fails' => true,
             ],
@@ -1595,26 +1595,26 @@ class RuleTest extends TestCase
                     'field-b' => 'b',
                 ],
             ],
-            'excludeIf match' => [
+            'excludeIfValue match' => [
                 'data' => [
                     'field-a' => 'a',
                     'field-b' => 'b',
                 ],
                 'rules' => fn() => [
-                    'field-a' => RuleSet::create()->excludeIf('field-b', 'b'),
+                    'field-a' => RuleSet::create()->excludeIfValue('field-b', 'b'),
                     'field-b' => RuleSet::create(),
                 ],
                 'expected' => [
                     'field-b' => 'b',
                 ],
             ],
-            'excludeIf not matched' => [
+            'excludeIfValue not matched' => [
                 'data' => [
                     'field-a' => 'a',
                     'field-b' => 'c',
                 ],
                 'rules' => fn() => [
-                    'field-a' => RuleSet::create()->excludeIf('field-b', 'b'),
+                    'field-a' => RuleSet::create()->excludeIfValue('field-b', 'b'),
                     'field-b' => RuleSet::create(),
                 ],
                 'expected' => [

--- a/tests/Unit/RuleTest.php
+++ b/tests/Unit/RuleTest.php
@@ -1596,6 +1596,25 @@ class RuleTest extends TestCase
                 'rules' => fn() => RuleSet::create()->uuid(),
                 'fails' => true,
             ],
+            'when valid' => [
+                'data' => 9,
+                'rules' => fn() => RuleSet::create()->when(fn() => false, RuleSet::create()->min(10)),
+                'fails' => false,
+            ],
+            'when invalid' => [
+                'data' => 9,
+                'rules' => fn() => RuleSet::create()->when(fn() => true, RuleSet::create()->min(10)),
+                'fails' => true,
+            ],
+            'when invalid fallback' => [
+                'data' => 9,
+                'rules' => fn() => RuleSet::create()->when(
+                    fn() => false,
+                    RuleSet::create()->numeric(),
+                    RuleSet::create()->string()
+                ),
+                'fails' => true,
+            ],
         ];
     }
 

--- a/tests/Unit/RuleTest.php
+++ b/tests/Unit/RuleTest.php
@@ -1696,6 +1696,37 @@ class RuleTest extends TestCase
                     'field-b' => 'c',
                 ],
             ],
+            'excludeWith match' => [
+                'data' => [
+                    'field-a' => 'a',
+                    'field-b' => 'b',
+                    'field-c' => 'c',
+                ],
+                'rules' => fn() => [
+                    'field-a' => RuleSet::create()->excludeWith('field-b'),
+                    'field-b' => RuleSet::create(),
+                    'field-c' => RuleSet::create(),
+                ],
+                'expected' => [
+                    'field-b' => 'b',
+                    'field-c' => 'c',
+                ],
+            ],
+            'excludeWith not matched' => [
+                'data' => [
+                    'field-a' => 'a',
+                    'field-c' => 'c',
+                ],
+                'rules' => fn() => [
+                    'field-a' => RuleSet::create()->excludeWith('field-b'),
+                    'field-b' => RuleSet::create(),
+                    'field-c' => RuleSet::create(),
+                ],
+                'expected' => [
+                    'field-a' => 'a',
+                    'field-c' => 'c',
+                ],
+            ],
             'excludeWithout match' => [
                 'data' => [
                     'field-a' => 'a',

--- a/tests/Unit/RuleTest.php
+++ b/tests/Unit/RuleTest.php
@@ -1145,6 +1145,26 @@ class RuleTest extends TestCase
                 ],
                 'fails' => true,
             ],
+            'prohibitedIf valid' => [
+                'data' => [
+                    'field-a' => '',
+                    'field-b' => 'b',
+                ],
+                'rules' => fn() => [
+                    'field-a' => RuleSet::create()->prohibitedIf(true),
+                ],
+                'fails' => false,
+            ],
+            'prohibitedIf invalid' => [
+                'data' => [
+                    'field-a' => 'a',
+                    'field-b' => 'b',
+                ],
+                'rules' => fn() => [
+                    'field-a' => RuleSet::create()->prohibitedIf(true),
+                ],
+                'fails' => true,
+            ],
             'prohibitedIfValue valid' => [
                 'data' => [
                     'field-a' => '',
@@ -1593,6 +1613,33 @@ class RuleTest extends TestCase
                 ],
                 'expected' => [
                     'field-b' => 'b',
+                ],
+            ],
+            'excludeIf match' => [
+                'data' => [
+                    'field-a' => 'a',
+                    'field-b' => 'b',
+                ],
+                'rules' => fn() => [
+                    'field-a' => RuleSet::create()->excludeIf(true),
+                    'field-b' => RuleSet::create(),
+                ],
+                'expected' => [
+                    'field-b' => 'b',
+                ],
+            ],
+            'excludeIf not matched' => [
+                'data' => [
+                    'field-a' => 'a',
+                    'field-b' => 'c',
+                ],
+                'rules' => fn() => [
+                    'field-a' => RuleSet::create()->excludeIf(false),
+                    'field-b' => RuleSet::create(),
+                ],
+                'expected' => [
+                    'field-a' => 'a',
+                    'field-b' => 'c',
                 ],
             ],
             'excludeIfValue match' => [

--- a/tests/Unit/RuleTest.php
+++ b/tests/Unit/RuleTest.php
@@ -786,6 +786,82 @@ class RuleTest extends TestCase
                 'rules' => fn() => RuleSet::create()->filled(),
                 'fails' => true,
             ],
+            'forEach valid' => [
+                'data' => [
+                    'values' => [
+                        [
+                            'type' => 'post',
+                            'name' => 'Test Post',
+                        ],
+                        [
+                            'type' => 'comment',
+                            'content' => 'Test Comment',
+                        ],
+                    ],
+                ],
+                'rules' => fn() => [
+                    'values.*' => RuleSet::create()->forEach(fn($value) => match ($value['type']) {
+                        'post' => [
+                            'name' => RuleSet::create()->required(),
+                        ],
+                        'comment' => [
+                            'content' => RuleSet::create()->required(),
+                        ],
+                    }),
+                ],
+                'fails' => false,
+            ],
+            'forEach invalid' => [
+                'data' => [
+                    'values' => [
+                        [
+                            'type' => 'post',
+                            'name' => 'Test Post',
+                        ],
+                        [
+                            'type' => 'comment',
+                            'name' => 'Test Comment',
+                        ],
+                    ],
+                ],
+                'rules' => fn() => [
+                    'values.*' => RuleSet::create()->forEach(fn($value) => match ($value['type']) {
+                        'post' => [
+                            'name' => RuleSet::create()->required(),
+                        ],
+                        'comment' => [
+                            'content' => RuleSet::create()->required(),
+                        ],
+                    }),
+                ],
+                'fails' => true,
+            ],
+            'forEach element valid' => [
+                'data' => [
+                    'values' => [
+                        [
+                            'id' => 2,
+                        ],
+                    ],
+                ],
+                'rules' => fn() => [
+                    'values.*.id' => RuleSet::create()->forEach(fn($id) => RuleSet::create()->prohibitedIf($id === 3)),
+                ],
+                'fails' => false,
+            ],
+            'forEach element invalid' => [
+                'data' => [
+                    'values' => [
+                        [
+                            'id' => 3,
+                        ],
+                    ],
+                ],
+                'rules' => fn() => [
+                    'values.*.id' => RuleSet::create()->forEach(fn($id) => RuleSet::create()->prohibitedIf($id === 3)),
+                ],
+                'fails' => true,
+            ],
             'gt valid' => [
                 'data' => [
                     'field-a' => '2',


### PR DESCRIPTION
The most recent merge had its tests fail due to the base Rule class being modified between the PR being created and merged,

This PR removes the extension of the base Rule class to prevent potential conflicts when Laravel updates.  It also include the new helpers that caused the conflict.

----

Edit: I went with 1 in this PR.

Some potential approaches to prevent fatal errors when a base Rule update is not compatible with our Rule class:

1. Don't extend Rule and instead include their methods in our class.
2. Don't extend Rule and use a __callStatic method to forward unknown rules to Laravel's helper.

I think the main benefit of 2 over 1 would be not needing to update our Rule class when Laravel's updates but I am not sure there is much value there since we'd want to update RuleSet in that case anyway.

The callStatic approach would likely look something like this:

```php
use Illuminate\Validation\Rule as LaravelRule;

/**
 * @mixin LaravelRule
 */
class Rule
{
    public static function __callStatic(string $name, array $arguments)
    {
        if (method_exists(LaravelRule::class, $name)) {
            return call_user_func([LaravelRule::class, $name], ...$arguments);
        }

        throw new \BadMethodCallException('Unknown Rule method '.$name);
    }

    // ...
}
```
