### PR TITLE
Implement IteratorAggregate on the RuleSet

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,12 @@ The defined set can then be used in rules using `RuleSet::useDefined`.
     }
 ```
 
+To concatenate a defined ruleset you can spread the ruleset as arguments for the concat method.
+
+```php
+RuleSet::create()->required()->concat(...RuleSet::useDefined('existing_email'));
+```
+
 #### requiredIfAll
 
 Accepts multiple `RequiredIf` rules and only marks as required if all return true.

--- a/README.md
+++ b/README.md
@@ -95,12 +95,6 @@ The defined set can then be used in rules using `RuleSet::useDefined`.
     }
 ```
 
-To concatenate a defined ruleset you can spread the ruleset as arguments for the concat method.
-
-```php
-RuleSet::create()->required()->concat(...RuleSet::useDefined('existing_email'));
-```
-
 #### requiredIfAll
 
 Accepts multiple `RequiredIf` rules and only marks as required if all return true.

--- a/src/RuleSet.php
+++ b/src/RuleSet.php
@@ -4,14 +4,21 @@ declare(strict_types=1);
 
 namespace Sourcetoad\RuleHelper;
 
+use ArrayIterator;
 use DateTimeInterface;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Validation\Rules\RequiredIf;
+use IteratorAggregate;
 
-class RuleSet implements Arrayable
+class RuleSet implements Arrayable, IteratorAggregate
 {
     public function __construct(protected array $rules = [])
     {
+    }
+
+    public function getIterator(): ArrayIterator
+    {
+        return new ArrayIterator($this->rules);
     }
 
     /**


### PR DESCRIPTION
~Implemented IteratorAggregate on RuleSet to allow it to be spread to make concatenation a little saner.~

This actually didn't work as expected. You also need to implement ArrayAccess, and then PHPStorm complained about spreading RuleSet into concat anyways because of the typing. None of the generic support made it work. I think this is still beneficial, but it doesn't accomplish what I was hoping for.