### PR TITLE
Laravel 9.45 Updates

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "minimum-stability": "stable",
     "require": {
         "php": "^8.0",
-        "laravel/framework": "^9.44"
+        "laravel/framework": "^9.45"
     },
     "require-dev": {
         "ext-json": "*",

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "minimum-stability": "stable",
     "require": {
         "php": "^8.0",
-        "laravel/framework": "^9.40"
+        "laravel/framework": "^9.44"
     },
     "require-dev": {
         "ext-json": "*",

--- a/src/Rule.php
+++ b/src/Rule.php
@@ -117,6 +117,16 @@ class Rule
     }
 
     /**
+     * The field under validation must be entirely 7-bit ASCII characters.
+     *
+     * @link https://laravel.com/docs/9.x/validation#rule-ascii
+     */
+    public static function ascii(): string
+    {
+        return 'ascii';
+    }
+
+    /**
      * Stop running validation rules for the field after the first validation failure.
      *
      * @link https://laravel.com/docs/9.x/validation#rule-bail
@@ -968,6 +978,17 @@ class Rule
     public static function timezone(): string
     {
         return 'timezone';
+    }
+
+    /**
+     * The field under validation must be a valid Universally Unique Lexicographically Sortable Identifier (ULID).
+     *
+     * @link https://laravel.com/docs/9.x/validation#rule-ulid
+     * @link https://github.com/ulid/spec
+     */
+    public static function ulid(): string
+    {
+        return 'ulid';
     }
 
     /**

--- a/src/Rule.php
+++ b/src/Rule.php
@@ -233,6 +233,16 @@ class Rule
     }
 
     /**
+     * The field under validation must be numeric and must contain the specified number of decimal places.
+     *
+     * @link https://laravel.com/docs/9.x/validation#rule-decimal
+     */
+    public static function decimal(int $precision, ?int $maxPrecision = null): string
+    {
+        return 'decimal:'.$precision.($maxPrecision !== null ? ','.$maxPrecision : '');
+    }
+
+    /**
      * The field under validation must be *"no"*, *"off"*, *0*, or *false*.
      *
      * @link https://laravel.com/docs/9.x/validation#rule-declined

--- a/src/RuleSet.php
+++ b/src/RuleSet.php
@@ -288,6 +288,16 @@ class RuleSet implements Arrayable, IteratorAggregate
     }
 
     /**
+     * The field under validation must be numeric and must contain the specified number of decimal places.
+     *
+     * @link https://laravel.com/docs/9.x/validation#rule-decimal
+     */
+    public function decimal(int $precision, ?int $maxPrecision = null): self
+    {
+        return $this->rule(Rule::decimal($precision, $maxPrecision));
+    }
+
+    /**
      * The field under validation must be *"no"*, *"off"*, *0*, or *false*.
      *
      * @link https://laravel.com/docs/9.x/validation#rule-declined

--- a/src/RuleSet.php
+++ b/src/RuleSet.php
@@ -176,6 +176,16 @@ class RuleSet implements Arrayable, IteratorAggregate
     }
 
     /**
+     * The field under validation must be entirely 7-bit ASCII characters.
+     *
+     * @link https://laravel.com/docs/9.x/validation#rule-ascii
+     */
+    public function ascii(): self
+    {
+        return $this->rule(Rule::ascii());
+    }
+
+    /**
      * Stop running validation rules for the field after the first validation failure.
      *
      * @link https://laravel.com/docs/9.x/validation#rule-bail
@@ -1025,6 +1035,17 @@ class RuleSet implements Arrayable, IteratorAggregate
     public function timezone(): self
     {
         return $this->rule(Rule::timezone());
+    }
+
+    /**
+     * The field under validation must be a valid Universally Unique Lexicographically Sortable Identifier (ULID).
+     *
+     * @link https://laravel.com/docs/9.x/validation#rule-ulid
+     * @link https://github.com/ulid/spec
+     */
+    public function ulid(): self
+    {
+        return $this->rule(Rule::ulid());
     }
 
     /**

--- a/tests/Unit/RuleTest.php
+++ b/tests/Unit/RuleTest.php
@@ -487,6 +487,26 @@ class RuleTest extends TestCase
                 'rules' => fn() => RuleSet::create()->dateFormat('d-M-Y'),
                 'fails' => true,
             ],
+            'decimal valid' => [
+                'data' => '1.1',
+                'rules' => fn() => RuleSet::create()->decimal(1),
+                'fails' => false,
+            ],
+            'decimal invalid not decimal' => [
+                'data' => '1',
+                'rules' => fn() => RuleSet::create()->decimal(1),
+                'fails' => true,
+            ],
+            'decimal invalid wrong precision' => [
+                'data' => '1.01',
+                'rules' => fn() => RuleSet::create()->decimal(1),
+                'fails' => true,
+            ],
+            'decimal invalid with max' => [
+                'data' => '1.12345',
+                'rules' => fn() => RuleSet::create()->decimal(1, 4),
+                'fails' => true,
+            ],
             'declined valid' => [
                 'data' => '0',
                 'rules' => fn() => RuleSet::create()->declined(),

--- a/tests/Unit/RuleTest.php
+++ b/tests/Unit/RuleTest.php
@@ -295,6 +295,21 @@ class RuleTest extends TestCase
                 ],
                 'fails' => true,
             ],
+            'ascii valid' => [
+                'data' => 'Ascii',
+                'rules' => fn() => RuleSet::create()->ascii(),
+                'fails' => false,
+            ],
+            'ascii invalid non-breaking space' => [
+                'data' => 'Ascii with NBSP',
+                'rules' => fn() => RuleSet::create()->ascii(),
+                'fails' => true,
+            ],
+            'ascii invalid utf-8' => [
+                'data' => 'アスキー',
+                'rules' => fn() => RuleSet::create()->ascii(),
+                'fails' => true,
+            ],
             'bail not set' => [
                 'data' => 11,
                 'rules' => fn() => RuleSet::create()->max(1)->string(),
@@ -1664,6 +1679,16 @@ class RuleTest extends TestCase
             'timezone invalid' => [
                 'data' => 'not a timezone',
                 'rules' => fn() => RuleSet::create()->timezone(),
+                'fails' => true,
+            ],
+            'ulid valid' => [
+                'data' => Str::ulid()->toBase32(),
+                'rules' => fn() => RuleSet::create()->ulid(),
+                'fails' => false,
+            ],
+            'ulid invalid' => [
+                'data' => Str::uuid()->toString(),
+                'rules' => fn() => RuleSet::create()->ulid(),
                 'fails' => true,
             ],
             'uppercase valid' => [


### PR DESCRIPTION
Adds `ascii`, `ulid`, and `decimal` rules.