### PR TITLE
Adding `password` helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Adds helpers to make building Laravel rule arrays easier by providing helper met
 ## Installation
 
 ```shell
-$ composer require sourcetoad/rule-helper-for-laravel
+composer require sourcetoad/rule-helper-for-laravel
 ```
 
 ## Usage

--- a/src/Rule.php
+++ b/src/Rule.php
@@ -14,6 +14,7 @@ use Illuminate\Validation\Rules\ExcludeIf;
 use Illuminate\Validation\Rules\Exists;
 use Illuminate\Validation\Rules\In;
 use Illuminate\Validation\Rules\NotIn;
+use Illuminate\Validation\Rules\Password;
 use Illuminate\Validation\Rules\ProhibitedIf;
 use Illuminate\Validation\Rules\RequiredIf;
 use Illuminate\Validation\Rules\Unique;
@@ -776,6 +777,19 @@ class Rule
     public static function numeric(): string
     {
         return 'numeric';
+    }
+
+    /**
+     * The field under validation must be a string with an adequate level of complexity for a password. Defaults to a
+     * minimum of 8 characters if no size is provided and {@see Password::defaults} was not used.
+     *
+     * @link https://laravel.com/docs/10.x/validation#validating-passwords
+     */
+    public static function password(?int $size = null): Password
+    {
+        return $size === null
+            ? Password::default()
+            : Password::min($size);
     }
 
     /**

--- a/src/RuleSet.php
+++ b/src/RuleSet.php
@@ -65,8 +65,6 @@ class RuleSet implements Arrayable, IteratorAggregate
 
     /**
      * Append all rules from a defined rule set.
-     *
-     * @param string $name
      */
     public function concatDefined(string $name): self
     {

--- a/src/RuleSet.php
+++ b/src/RuleSet.php
@@ -8,6 +8,7 @@ use ArrayIterator;
 use DateTimeInterface;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Validation\Rules\RequiredIf;
+use Illuminate\Validation\Rules\Password;
 use IteratorAggregate;
 
 class RuleSet implements Arrayable, IteratorAggregate
@@ -835,6 +836,26 @@ class RuleSet implements Arrayable, IteratorAggregate
     public function numeric(): self
     {
         return $this->rule(Rule::numeric());
+    }
+
+    /**
+     * The field under validation must be a string with an adequate level of complexity for a password. Defaults to a
+     * minimum of 8 characters if no size is provided and {@see Password::defaults} was not used.
+     *
+     * If you would like to customize the password rule, you may use {@see Password::defaults} and pass no options,
+     * use {@see Rule::password} with {@see RuleSet::rule}, or pass a callback which accepts a {@see Password} instance.
+     *
+     * @link https://laravel.com/docs/10.x/validation#validating-passwords
+     */
+    public function password(?int $size = null, ?callable $modifier = null): self
+    {
+        $rule = Rule::password($size);
+
+        if ($modifier) {
+            $modifier($rule);
+        }
+
+        return $this->rule($rule);
     }
 
     /**

--- a/tests/Unit/RuleTest.php
+++ b/tests/Unit/RuleTest.php
@@ -1245,6 +1245,27 @@ class RuleTest extends TestCase
                 ],
                 'fails' => true,
             ],
+            'missingWithAll valid' => [
+                'data' => [
+                    'field-a' => 'mock',
+                    'field-c' => 'mock',
+                ],
+                'rules' => fn() => [
+                    'field-a' => RuleSet::create()->missingWithAll('field-b', 'field-c'),
+                ],
+                'fails' => false,
+            ],
+            'missingWithAll invalid' => [
+                'data' => [
+                    'field-a' => 'mock',
+                    'field-b' => 'mock',
+                    'field-c' => 'mock',
+                ],
+                'rules' => fn() => [
+                    'field-a' => RuleSet::create()->missingWithAll('field-b', 'field-c'),
+                ],
+                'fails' => true,
+            ],
             'multipleOf valid' => [
                 'data' => 9.9,
                 'rules' => fn() => RuleSet::create()->multipleOf(3.3),


### PR DESCRIPTION
This adds password as a wrapper around the Laravel Password rule class which is used to specify password complexity in a reusable way.

One concern I have with adding this, is that when this project first released we were supporting Laravel 8.x which had `password` as a rule for the current user’s password.  That rule was deprecated with `current_password` and removed in 9.x.  Since we haven’t supported 8.x for a year I thought it might be fine to add this, but if someone on Rule Helper 1.x and Laravel 8.x upgraded to this without paying attention, rather than getting a failure to find the password method and failing a password check with a server error, the password check would turn into a password complexity check instead (which is probably the worst way to break that type of check).

Happy to scrap this instead of anyone thinks that is concern worth not adding a helper method over.