### PR TITLE
Fixed allowed types on between rule

### DIFF
--- a/src/Rule.php
+++ b/src/Rule.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Sourcetoad\RuleHelper;
 
+use Brick\Math\BigNumber;
 use DateTimeInterface;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Support\Collection;
@@ -162,9 +163,9 @@ class Rule
      *
      * @link https://laravel.com/docs/10.x/validation#rule-between
      */
-    public static function between(int $min, int $max): string
+    public static function between(float|int|string|BigNumber $min, float|int|string|BigNumber $max): string
     {
-        return sprintf('between:%d,%d', $min, $max);
+        return sprintf('between:%s,%s', $min, $max);
     }
 
     /**

--- a/src/RuleSet.php
+++ b/src/RuleSet.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Sourcetoad\RuleHelper;
 
 use ArrayIterator;
+use Brick\Math\BigNumber;
 use DateTimeInterface;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Validation\Rules\RequiredIf;
@@ -219,7 +220,7 @@ class RuleSet implements Arrayable, IteratorAggregate
      *
      * @link https://laravel.com/docs/10.x/validation#rule-between
      */
-    public function between(int $min, int $max): self
+    public function between(float|int|string|BigNumber $min, float|int|string|BigNumber $max): self
     {
         return $this->rule(Rule::between($min, $max));
     }

--- a/tests/Unit/RuleTest.php
+++ b/tests/Unit/RuleTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Sourcetoad\RuleHelper\Tests\Unit;
 
+use Brick\Math\BigNumber;
 use Carbon\CarbonImmutable;
 use Closure;
 use DateTime;
@@ -416,12 +417,54 @@ class RuleTest extends TestCase
                 'rules' => fn() => RuleSet::create()->beforeOrEqual(new DateTime('2021-01-01')),
                 'fails' => true,
             ],
+            'between valid with float' => [
+                'data' => 0.5,
+                'rules' => fn() => RuleSet::create()->numeric()->between(0.1, 0.5),
+                'fails' => false,
+            ],
+            'between invalid with float' => [
+                'data' => 0.6,
+                'rules' => fn() => RuleSet::create()->numeric()->between(0.1, 0.5),
+                'fails' => true,
+            ],
+            'between valid with number' => [
+                'data' => 100,
+                'rules' => fn() => RuleSet::create()->numeric()->between(1, 100),
+                'fails' => false,
+            ],
+            'between invalid with number' => [
+                'data' => 101,
+                'rules' => fn() => RuleSet::create()->numeric()->between(1, 100),
+                'fails' => true,
+            ],
             'between valid with string' => [
+                'data' => 50,
+                'rules' => fn() => RuleSet::create()->numeric()->between('25', '75'),
+                'fails' => false,
+            ],
+            'between invalid with string' => [
+                'data' => 76,
+                'rules' => fn() => RuleSet::create()->numeric()->between('25', '75'),
+                'fails' => true,
+            ],
+            'between valid with BigNumber' => [
+                'data' => '9223372036854775809',
+                'rules' => fn() => RuleSet::create()->numeric()
+                    ->between(BigNumber::of('9223372036854775808'), BigNumber::of('9223372036854775810')),
+                'fails' => false,
+            ],
+            'between invalid with BigNumber' => [
+                'data' => '9223372036854775811',
+                'rules' => fn() => RuleSet::create()->numeric()
+                    ->between(BigNumber::of('9223372036854775808'), BigNumber::of('9223372036854775810')),
+                'fails' => true,
+            ],
+            'between valid with string length' => [
                 'data' => str_repeat('.', 10),
                 'rules' => fn() => RuleSet::create()->between(9, 11),
                 'fails' => false,
             ],
-            'between invalid with string' => [
+            'between invalid with string length' => [
                 'data' => str_repeat('.', 12),
                 'rules' => fn() => RuleSet::create()->between(9, 11),
                 'fails' => true,


### PR DESCRIPTION
Between supports more than just int like was originally typed.  This expands to use the fields supported by `BigNumber::isGreaterThanOrEqualTo` and `BigNumber::isLessThanOrEqualTo` which is what `ValidatesAttributes::validateBetween` uses for the comparisons.