### PR TITLE
Fixed allowed types on integer comparison rules

### DIFF
--- a/src/Rule.php
+++ b/src/Rule.php
@@ -623,9 +623,9 @@ class Rule
      *
      * @link https://laravel.com/docs/10.x/validation#rule-max
      */
-    public static function max(int $value): string
+    public static function max(BigNumber|int|float|string $value): string
     {
-        return 'max:'.$value;
+        return sprintf('max:%s', $value);
     }
 
     /**
@@ -664,9 +664,9 @@ class Rule
      *
      * @link https://laravel.com/docs/10.x/validation#rule-min
      */
-    public static function min(int $value): string
+    public static function min(BigNumber|int|float|string $value): string
     {
-        return 'min:'.$value;
+        return sprintf('min:%s', $value);
     }
 
     /**
@@ -1007,9 +1007,9 @@ class Rule
      *
      * @link https://laravel.com/docs/10.x/validation#rule-size
      */
-    public static function size(int $value): string
+    public static function size(BigNumber|int|float|string $value): string
     {
-        return 'size:'.$value;
+        return sprintf('size:%s', $value);
     }
 
     /**

--- a/src/Rule.php
+++ b/src/Rule.php
@@ -477,9 +477,9 @@ class Rule
      *
      * @link https://laravel.com/docs/10.x/validation#rule-gt
      */
-    public static function gt(string $field): string
+    public static function gt(BigNumber|int|float|string $field): string
     {
-        return 'gt:'.$field;
+        return sprintf('gt:%s', $field);
     }
 
     /**
@@ -487,9 +487,9 @@ class Rule
      *
      * @link https://laravel.com/docs/10.x/validation#rule-gte
      */
-    public static function gte(string $field): string
+    public static function gte(BigNumber|int|float|string $field): string
     {
-        return 'gte:'.$field;
+        return sprintf('gte:%s', $field);
     }
 
     /**
@@ -593,9 +593,9 @@ class Rule
      *
      * @link https://laravel.com/docs/10.x/validation#rule-lt
      */
-    public static function lt(string $field): string
+    public static function lt(BigNumber|int|float|string $field): string
     {
-        return 'lt:'.$field;
+        return sprintf('lt:%s', $field);
     }
 
     /**
@@ -603,9 +603,9 @@ class Rule
      *
      * @link https://laravel.com/docs/10.x/validation#rule-lte
      */
-    public static function lte(string $field): string
+    public static function lte(BigNumber|int|float|string $field): string
     {
-        return 'lte:'.$field;
+        return sprintf('lte:%s', $field);
     }
 
     /**

--- a/src/RuleSet.php
+++ b/src/RuleSet.php
@@ -682,7 +682,7 @@ class RuleSet implements Arrayable, IteratorAggregate
      *
      * @link https://laravel.com/docs/10.x/validation#rule-max
      */
-    public function max(int $value): self
+    public function max(BigNumber|int|float|string $value): self
     {
         return $this->rule(Rule::max($value));
     }
@@ -723,7 +723,7 @@ class RuleSet implements Arrayable, IteratorAggregate
      *
      * @link https://laravel.com/docs/10.x/validation#rule-min
      */
-    public function min(int $value): self
+    public function min(BigNumber|int|float|string $value): self
     {
         return $this->rule(Rule::min($value));
     }
@@ -1069,7 +1069,7 @@ class RuleSet implements Arrayable, IteratorAggregate
      *
      * @link https://laravel.com/docs/10.x/validation#rule-size
      */
-    public function size(int $value): self
+    public function size(BigNumber|int|float|string $value): self
     {
         return $this->rule(Rule::size($value));
     }

--- a/src/RuleSet.php
+++ b/src/RuleSet.php
@@ -536,7 +536,7 @@ class RuleSet implements Arrayable, IteratorAggregate
      *
      * @link https://laravel.com/docs/10.x/validation#rule-gt
      */
-    public function gt(string $field): self
+    public function gt(BigNumber|int|float|string $field): self
     {
         return $this->rule(Rule::gt($field));
     }
@@ -546,7 +546,7 @@ class RuleSet implements Arrayable, IteratorAggregate
      *
      * @link https://laravel.com/docs/10.x/validation#rule-gte
      */
-    public function gte(string $field): self
+    public function gte(BigNumber|int|float|string $field): self
     {
         return $this->rule(Rule::gte($field));
     }
@@ -652,7 +652,7 @@ class RuleSet implements Arrayable, IteratorAggregate
      *
      * @link https://laravel.com/docs/10.x/validation#rule-lt
      */
-    public function lt(string $field): self
+    public function lt(BigNumber|int|float|string $field): self
     {
         return $this->rule(Rule::lt($field));
     }
@@ -662,7 +662,7 @@ class RuleSet implements Arrayable, IteratorAggregate
      *
      * @link https://laravel.com/docs/10.x/validation#rule-lte
      */
-    public function lte(string $field): self
+    public function lte(BigNumber|int|float|string $field): self
     {
         return $this->rule(Rule::lte($field));
     }

--- a/tests/Unit/RuleTest.php
+++ b/tests/Unit/RuleTest.php
@@ -1153,12 +1153,54 @@ class RuleTest extends TestCase
                 'rules' => fn() => RuleSet::create()->macAddress(),
                 'fails' => true,
             ],
+            'max valid with float' => [
+                'data' => 0.5,
+                'rules' => fn() => RuleSet::create()->numeric()->max(0.5),
+                'fails' => false,
+            ],
+            'max invalid with float' => [
+                'data' => 0.6,
+                'rules' => fn() => RuleSet::create()->numeric()->max(0.5),
+                'fails' => true,
+            ],
+            'max valid with number' => [
+                'data' => 100,
+                'rules' => fn() => RuleSet::create()->numeric()->max(100),
+                'fails' => false,
+            ],
+            'max invalid with number' => [
+                'data' => 101,
+                'rules' => fn() => RuleSet::create()->numeric()->max(100),
+                'fails' => true,
+            ],
             'max valid with string' => [
+                'data' => 24,
+                'rules' => fn() => RuleSet::create()->numeric()->max('25'),
+                'fails' => false,
+            ],
+            'max invalid with string' => [
+                'data' => 76,
+                'rules' => fn() => RuleSet::create()->numeric()->max('75'),
+                'fails' => true,
+            ],
+            'max valid with BigNumber' => [
+                'data' => '9223372036854775809',
+                'rules' => fn() => RuleSet::create()->numeric()
+                    ->max(BigNumber::of('9223372036854775810')),
+                'fails' => false,
+            ],
+            'max invalid with BigNumber' => [
+                'data' => '9223372036854775811',
+                'rules' => fn() => RuleSet::create()->numeric()
+                    ->max(BigNumber::of('9223372036854775810')),
+                'fails' => true,
+            ],
+            'max valid with string length' => [
                 'data' => str_repeat('.', 10),
                 'rules' => fn() => RuleSet::create()->max(10),
                 'fails' => false,
             ],
-            'max invalid with string' => [
+            'max invalid with string length' => [
                 'data' => str_repeat('.', 11),
                 'rules' => fn() => RuleSet::create()->max(10),
                 'fails' => true,
@@ -1207,12 +1249,54 @@ class RuleTest extends TestCase
                 'rules' => fn() => RuleSet::create()->mimetypes('image/gif', 'application/pdf'),
                 'fails' => true,
             ],
+            'min valid with float' => [
+                'data' => 0.5,
+                'rules' => fn() => RuleSet::create()->numeric()->min(0.5),
+                'fails' => false,
+            ],
+            'min invalid with float' => [
+                'data' => 0.1,
+                'rules' => fn() => RuleSet::create()->numeric()->min(0.5),
+                'fails' => true,
+            ],
+            'min valid with number' => [
+                'data' => 100,
+                'rules' => fn() => RuleSet::create()->numeric()->min(100),
+                'fails' => false,
+            ],
+            'min invalid with number' => [
+                'data' => 99,
+                'rules' => fn() => RuleSet::create()->numeric()->min(100),
+                'fails' => true,
+            ],
             'min valid with string' => [
+                'data' => 76,
+                'rules' => fn() => RuleSet::create()->numeric()->min('75'),
+                'fails' => false,
+            ],
+            'min invalid with string' => [
+                'data' => 24,
+                'rules' => fn() => RuleSet::create()->numeric()->min('25'),
+                'fails' => true,
+            ],
+            'min valid with BigNumber' => [
+                'data' => '9223372036854775811',
+                'rules' => fn() => RuleSet::create()->numeric()
+                    ->min(BigNumber::of('9223372036854775810')),
+                'fails' => false,
+            ],
+            'min invalid with BigNumber' => [
+                'data' => '9223372036854775809',
+                'rules' => fn() => RuleSet::create()->numeric()
+                    ->min(BigNumber::of('9223372036854775810')),
+                'fails' => true,
+            ],
+            'min valid with string length' => [
                 'data' => str_repeat('.', 11),
                 'rules' => fn() => RuleSet::create()->min(10),
                 'fails' => false,
             ],
-            'min invalid with string' => [
+            'min invalid with string length' => [
                 'data' => str_repeat('.', 9),
                 'rules' => fn() => RuleSet::create()->min(10),
                 'fails' => true,
@@ -1887,12 +1971,54 @@ class RuleTest extends TestCase
                 ],
                 'fails' => true,
             ],
-            'size valid' => [
+            'size valid with float' => [
+                'data' => 1.0,
+                'rules' => fn() => RuleSet::create()->numeric()->size(1.0),
+                'fails' => false,
+            ],
+            'size invalid with float' => [
+                'data' => 1.0,
+                'rules' => fn() => RuleSet::create()->numeric()->size(1.1),
+                'fails' => true,
+            ],
+            'size valid with number' => [
+                'data' => 100,
+                'rules' => fn() => RuleSet::create()->numeric()->size(100),
+                'fails' => false,
+            ],
+            'size invalid with number' => [
+                'data' => 101,
+                'rules' => fn() => RuleSet::create()->numeric()->size(100),
+                'fails' => true,
+            ],
+            'size valid with string' => [
+                'data' => 75,
+                'rules' => fn() => RuleSet::create()->numeric()->size('75'),
+                'fails' => false,
+            ],
+            'size invalid with string' => [
+                'data' => 76,
+                'rules' => fn() => RuleSet::create()->numeric()->size('75'),
+                'fails' => true,
+            ],
+            'size valid with BigNumber' => [
+                'data' => '9223372036854775809',
+                'rules' => fn() => RuleSet::create()->numeric()
+                    ->size(BigNumber::of('9223372036854775809')),
+                'fails' => false,
+            ],
+            'size invalid with BigNumber' => [
+                'data' => '9223372036854775809',
+                'rules' => fn() => RuleSet::create()->numeric()
+                    ->size(BigNumber::of('9223372036854775808')),
+                'fails' => true,
+            ],
+            'size valid with string length' => [
                 'data' => 'str',
                 'rules' => fn() => RuleSet::create()->size(3),
                 'fails' => false,
             ],
-            'size invalid' => [
+            'size invalid with string length' => [
                 'data' => 'string',
                 'rules' => fn() => RuleSet::create()->size(3),
                 'fails' => true,

--- a/tests/Unit/RuleTest.php
+++ b/tests/Unit/RuleTest.php
@@ -949,7 +949,39 @@ class RuleTest extends TestCase
                 'rules' => fn() => RuleSet::create()->filled(),
                 'fails' => true,
             ],
-            'gt valid' => [
+            'gt valid with float' => [
+                'data' => 0.6,
+                'rules' => fn() => RuleSet::create()->numeric()->gt(0.5),
+                'fails' => false,
+            ],
+            'gt invalid with float' => [
+                'data' => 0.5,
+                'rules' => fn() => RuleSet::create()->numeric()->gt(0.5),
+                'fails' => true,
+            ],
+            'gt valid with number' => [
+                'data' => 101,
+                'rules' => fn() => RuleSet::create()->numeric()->gt(100),
+                'fails' => false,
+            ],
+            'gt invalid with number' => [
+                'data' => 100,
+                'rules' => fn() => RuleSet::create()->numeric()->gt(100),
+                'fails' => true,
+            ],
+            'gt valid with BigNumber' => [
+                'data' => '9223372036854775811',
+                'rules' => fn() => RuleSet::create()->numeric()
+                    ->gt(BigNumber::of('9223372036854775810')),
+                'fails' => false,
+            ],
+            'gt invalid with BigNumber' => [
+                'data' => '9223372036854775810',
+                'rules' => fn() => RuleSet::create()->numeric()
+                    ->gt(BigNumber::of('9223372036854775810')),
+                'fails' => true,
+            ],
+            'gt valid with string' => [
                 'data' => [
                     'field-a' => '2',
                     'field-b' => '1',
@@ -959,7 +991,7 @@ class RuleTest extends TestCase
                 ],
                 'fails' => false,
             ],
-            'gt invalid' => [
+            'gt invalid with string' => [
                 'data' => [
                     'field-a' => '1',
                     'field-b' => '2',
@@ -969,7 +1001,39 @@ class RuleTest extends TestCase
                 ],
                 'fails' => true,
             ],
-            'gte valid' => [
+            'gte valid with float' => [
+                'data' => 0.5,
+                'rules' => fn() => RuleSet::create()->numeric()->gte(0.5),
+                'fails' => false,
+            ],
+            'gte invalid with float' => [
+                'data' => 0.4,
+                'rules' => fn() => RuleSet::create()->numeric()->gte(0.5),
+                'fails' => true,
+            ],
+            'gte valid with number' => [
+                'data' => 100,
+                'rules' => fn() => RuleSet::create()->numeric()->gte(100),
+                'fails' => false,
+            ],
+            'gte invalid with number' => [
+                'data' => 99,
+                'rules' => fn() => RuleSet::create()->numeric()->gte(100),
+                'fails' => true,
+            ],
+            'gte valid with BigNumber' => [
+                'data' => '9223372036854775810',
+                'rules' => fn() => RuleSet::create()->numeric()
+                    ->gte(BigNumber::of('9223372036854775810')),
+                'fails' => false,
+            ],
+            'gte invalid with BigNumber' => [
+                'data' => '9223372036854775809',
+                'rules' => fn() => RuleSet::create()->numeric()
+                    ->gte(BigNumber::of('9223372036854775810')),
+                'fails' => true,
+            ],
+            'gte valid with string' => [
                 'data' => [
                     'field-a' => '1',
                     'field-b' => '1',
@@ -979,7 +1043,7 @@ class RuleTest extends TestCase
                 ],
                 'fails' => false,
             ],
-            'gte invalid' => [
+            'gte invalid with string' => [
                 'data' => [
                     'field-a' => '1',
                     'field-b' => '2',
@@ -1103,7 +1167,39 @@ class RuleTest extends TestCase
                 'rules' => fn() => RuleSet::create()->lowercase(),
                 'fails' => true,
             ],
-            'lt valid' => [
+            'lt valid with float' => [
+                'data' => 0.4,
+                'rules' => fn() => RuleSet::create()->numeric()->lt(0.5),
+                'fails' => false,
+            ],
+            'lt invalid with float' => [
+                'data' => 0.5,
+                'rules' => fn() => RuleSet::create()->numeric()->lt(0.5),
+                'fails' => true,
+            ],
+            'lt valid with number' => [
+                'data' => 99,
+                'rules' => fn() => RuleSet::create()->numeric()->lt(100),
+                'fails' => false,
+            ],
+            'lt invalid with number' => [
+                'data' => 100,
+                'rules' => fn() => RuleSet::create()->numeric()->lt(100),
+                'fails' => true,
+            ],
+            'lt valid with BigNumber' => [
+                'data' => '9223372036854775809',
+                'rules' => fn() => RuleSet::create()->numeric()
+                    ->lt(BigNumber::of('9223372036854775810')),
+                'fails' => false,
+            ],
+            'lt invalid with BigNumber' => [
+                'data' => '9223372036854775810',
+                'rules' => fn() => RuleSet::create()->numeric()
+                    ->lt(BigNumber::of('9223372036854775810')),
+                'fails' => true,
+            ],
+            'lt valid with string' => [
                 'data' => [
                     'field-a' => '1',
                     'field-b' => '2',
@@ -1113,7 +1209,7 @@ class RuleTest extends TestCase
                 ],
                 'fails' => false,
             ],
-            'lt invalid' => [
+            'lt invalid with string' => [
                 'data' => [
                     'field-a' => '2',
                     'field-b' => '1',
@@ -1123,7 +1219,39 @@ class RuleTest extends TestCase
                 ],
                 'fails' => true,
             ],
-            'lte valid' => [
+            'lte valid with float' => [
+                'data' => 0.5,
+                'rules' => fn() => RuleSet::create()->numeric()->lte(0.5),
+                'fails' => false,
+            ],
+            'lte invalid with float' => [
+                'data' => 0.6,
+                'rules' => fn() => RuleSet::create()->numeric()->lte(0.5),
+                'fails' => true,
+            ],
+            'lte valid with number' => [
+                'data' => 100,
+                'rules' => fn() => RuleSet::create()->numeric()->lte(100),
+                'fails' => false,
+            ],
+            'lte invalid with number' => [
+                'data' => 101,
+                'rules' => fn() => RuleSet::create()->numeric()->lte(100),
+                'fails' => true,
+            ],
+            'lte valid with BigNumber' => [
+                'data' => '9223372036854775810',
+                'rules' => fn() => RuleSet::create()->numeric()
+                    ->lte(BigNumber::of('9223372036854775810')),
+                'fails' => false,
+            ],
+            'lte invalid with BigNumber' => [
+                'data' => '9223372036854775811',
+                'rules' => fn() => RuleSet::create()->numeric()
+                    ->lte(BigNumber::of('9223372036854775810')),
+                'fails' => true,
+            ],
+            'lte valid with string' => [
                 'data' => [
                     'field-a' => '1',
                     'field-b' => '1',
@@ -1133,7 +1261,7 @@ class RuleTest extends TestCase
                 ],
                 'fails' => false,
             ],
-            'lte invalid' => [
+            'lte invalid with string' => [
                 'data' => [
                     'field-a' => '2',
                     'field-b' => '1',


### PR DESCRIPTION
I went too fast in my updating of `between` and missed that `min`, `max`, `size`, `lt`, `lte`, `gt`, and `gte` use the same BigNumber comparisons internally so support the same types.

I don't see a ton of value in comparing a `size` of float since it really is just a value equals comparison compared to the rest which also work on array or string sizes, but I included it in case there is a useful case I am missing.