### PR TITLE
In type fixes

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -4,7 +4,7 @@
 
 ### Upgrading from v5.0 to v5.1
 
-- Minimum Laravel version increased from `11.0.3` to `11.4`.
+- Minimum Laravel version increased from `11.0.3` to `11.5`.
 
 ### Upgrading from v4.3 to v5.0
 

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "minimum-stability": "stable",
     "require": {
         "php": "^8.2",
-        "laravel/framework": "^11.4"
+        "laravel/framework": "^11.5"
     },
     "require-dev": {
         "ext-json": "*",

--- a/src/Rule.php
+++ b/src/Rule.php
@@ -632,7 +632,10 @@ class Rule
     }
 
     /**
-     * The field under validation must be a list style array.
+     * The field under validation must be an array that is a list. An array is considered a list if its keys consist of
+     * consecutive numbers from 0 to count($array) - 1.
+     *
+     * @link https://laravel.com/docs/11.x/validation#rule-list
      */
     public static function list(): string
     {
@@ -866,8 +869,9 @@ class Rule
     }
 
     /**
-     * The field under validation must be present but can be empty if *anotherField* under validation is equal to a
-     * specified value.
+     * The field under validation must be present if the *anotherField* field is equal to any *value*.
+     *
+     * @link https://laravel.com/docs/11.x/validation#rule-present-if
      */
     public static function presentIf(string $anotherField, string ...$value): string
     {
@@ -875,8 +879,9 @@ class Rule
     }
 
     /**
-     * The field under validation must be present but can be empty unless the *anotherField* field is equal to any
-     * *value*.
+     * The field under validation must be present unless the *anotherField* field is equal to any *value*.
+     *
+     * @link https://laravel.com/docs/11.x/validation#rule-present-unless
      */
     public static function presentUnless(string $anotherField, string ...$value): string
     {
@@ -884,8 +889,9 @@ class Rule
     }
 
     /**
-     * The field under validation must be present but can be empty *only if* any of the other specified fields are
-     * present and not empty.
+     * The field under validation must be present *only if* any of the other specified fields are present.
+     *
+     * @link https://laravel.com/docs/11.x/validation#rule-present-with
      */
     public static function presentWith(string ...$field): string
     {
@@ -893,8 +899,9 @@ class Rule
     }
 
     /**
-     * The field under validation must be present but can be empty *only if* all the other specified fields are present
-     * and not empty.
+     * The field under validation must be present *only if* all the other specified fields are present.
+     *
+     * @link https://laravel.com/docs/11.x/validation#rule-present-with-all
      */
     public static function presentWithAll(string ...$field): string
     {
@@ -996,7 +1003,7 @@ class Rule
     }
 
     /**
-     * The field under validation must be present and not empty if the `field` field is equal to yes, on, 1, "1", true,
+     * The field under validation must be present and not empty if the *field* field is equal to yes, on, 1, "1", true,
      * or "true".
      *
      * @link https://laravel.com/docs/11.x/validation#rule-required-if-accepted
@@ -1027,7 +1034,7 @@ class Rule
     }
 
     /**
-     * The field under validation must be present and not empty if the `field` field is equal to "no", "off", 0, "0",
+     * The field under validation must be present and not empty if the *field* field is equal to "no", "off", 0, "0",
      * false, or "false".
      *
      * @link https://laravel.com/docs/11.x/validation#rule-required-if-declined

--- a/src/Rule.php
+++ b/src/Rule.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Sourcetoad\RuleHelper;
 
+use BackedEnum;
 use Brick\Math\BigNumber;
 use DateTimeInterface;
 use Illuminate\Contracts\Support\Arrayable;
@@ -25,6 +26,7 @@ use Illuminate\Validation\Rules\ProhibitedIf;
 use Illuminate\Validation\Rules\RequiredIf;
 use Illuminate\Validation\Rules\Unique;
 use Stringable;
+use UnitEnum;
 
 class Rule
 {
@@ -561,9 +563,9 @@ class Rule
      * list of values provided to the *in* rule.
      *
      * @link https://laravel.com/docs/11.x/validation#rule-in
-     * @param Arrayable<array-key, mixed>|array<array-key, mixed>|string $values
+     * @param Arrayable<array-key, BackedEnum|UnitEnum|string>|array<BackedEnum|UnitEnum|string>|BackedEnum|UnitEnum|string $values
      */
-    public static function in(Arrayable|array|string $values): In
+    public static function in(Arrayable|BackedEnum|UnitEnum|array|string $values): In
     {
         return LaravelRule::in($values);
     }
@@ -807,9 +809,9 @@ class Rule
      * The field under validation must not be included in the given list of values.
      *
      * @link https://laravel.com/docs/11.x/validation#rule-not-in
-     * @param Arrayable<array-key, mixed>|array<array-key, mixed>|string $values
+     * @param Arrayable<array-key, BackedEnum|UnitEnum|string>|array<BackedEnum|UnitEnum|string>|BackedEnum|UnitEnum|string $values
      */
-    public static function notIn(Arrayable|array|string $values): NotIn
+    public static function notIn(Arrayable|BackedEnum|UnitEnum|array|string $values): NotIn
     {
         return LaravelRule::notIn($values);
     }

--- a/src/RuleSet.php
+++ b/src/RuleSet.php
@@ -12,7 +12,6 @@ use Illuminate\Contracts\Validation\InvokableRule;
 use Illuminate\Contracts\Validation\Rule as RuleContract;
 use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Validation\ConditionalRules;
-use Illuminate\Validation\Rules\Dimensions;
 use Illuminate\Validation\Rules\Password;
 use Illuminate\Validation\Rules\RequiredIf;
 use IteratorAggregate;
@@ -716,7 +715,10 @@ class RuleSet implements Arrayable, IteratorAggregate
     }
 
     /**
-     * The field under validation must be a list style array.
+     * The field under validation must be an array that is a list. An array is considered a list if its keys consist of
+     * consecutive numbers from 0 to count($array) - 1.
+     *
+     * @link https://laravel.com/docs/11.x/validation#rule-list
      */
     public function list(): self
     {
@@ -958,8 +960,9 @@ class RuleSet implements Arrayable, IteratorAggregate
     }
 
     /**
-     * The field under validation must be present but can be empty if *anotherField* under validation is equal to a
-     * specified value.
+     * The field under validation must be present if the *anotherField* field is equal to any *value*.
+     *
+     * @link https://laravel.com/docs/11.x/validation#rule-present-if
      */
     public function presentIf(string $anotherField, string ...$value): self
     {
@@ -967,8 +970,9 @@ class RuleSet implements Arrayable, IteratorAggregate
     }
 
     /**
-     * The field under validation must be present but can be empty unless the *anotherField* field is equal to any
-     * *value*.
+     * The field under validation must be present unless the *anotherField* field is equal to any *value*.
+     *
+     * @link https://laravel.com/docs/11.x/validation#rule-present-unless
      */
     public function presentUnless(string $anotherField, string ...$value): self
     {
@@ -976,8 +980,9 @@ class RuleSet implements Arrayable, IteratorAggregate
     }
 
     /**
-     * The field under validation must be present but can be empty *only if* any of the other specified fields are
-     * present and not empty.
+     * The field under validation must be present *only if* any of the other specified fields are present.
+     *
+     * @link https://laravel.com/docs/11.x/validation#rule-present-with
      */
     public function presentWith(string ...$field): self
     {
@@ -985,8 +990,9 @@ class RuleSet implements Arrayable, IteratorAggregate
     }
 
     /**
-     * The field under validation must be present but can be empty *only if* all the other specified fields are present
-     * and not empty.
+     * The field under validation must be present *only if* all the other specified fields are present.
+     *
+     * @link https://laravel.com/docs/11.x/validation#rule-present-with-all
      */
     public function presentWithAll(string ...$field): self
     {
@@ -1088,7 +1094,7 @@ class RuleSet implements Arrayable, IteratorAggregate
     }
 
     /**
-     * The field under validation must be present and not empty if the `field` field is equal to yes, on, 1, "1", true,
+     * The field under validation must be present and not empty if the *field* field is equal to yes, on, 1, "1", true,
      * or "true".
      *
      * @link https://laravel.com/docs/11.x/validation#rule-required-if-accepted
@@ -1115,7 +1121,7 @@ class RuleSet implements Arrayable, IteratorAggregate
     }
 
     /**
-     * The field under validation must be present and not empty if the `field` field is equal to "no", "off", 0, "0",
+     * The field under validation must be present and not empty if the *field* field is equal to "no", "off", 0, "0",
      * false, or "false".
      *
      * @link https://laravel.com/docs/11.x/validation#rule-required-if-declined

--- a/src/RuleSet.php
+++ b/src/RuleSet.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Sourcetoad\RuleHelper;
 
 use ArrayIterator;
+use BackedEnum;
 use Brick\Math\BigNumber;
 use DateTimeInterface;
 use Illuminate\Contracts\Support\Arrayable;
@@ -16,6 +17,7 @@ use Illuminate\Validation\Rules\Password;
 use Illuminate\Validation\Rules\RequiredIf;
 use IteratorAggregate;
 use Stringable;
+use UnitEnum;
 
 /**
  * @implements Arrayable<array-key, RuleContract|InvokableRule|ValidationRule|ConditionalRules|Stringable|string>
@@ -644,9 +646,9 @@ class RuleSet implements Arrayable, IteratorAggregate
      * list of values provided to the *in* rule.
      *
      * @link https://laravel.com/docs/11.x/validation#rule-in
-     * @param Arrayable<array-key, mixed>|array<array-key, mixed>|string $values
+     * @param Arrayable<array-key, BackedEnum|UnitEnum|string>|array<BackedEnum|UnitEnum|string>|BackedEnum|UnitEnum|string $values
      */
-    public function in(Arrayable|array|string $values): self
+    public function in(Arrayable|BackedEnum|UnitEnum|array|string $values): self
     {
         return $this->rule(Rule::in($values));
     }
@@ -890,9 +892,9 @@ class RuleSet implements Arrayable, IteratorAggregate
      * The field under validation must not be included in the given list of values.
      *
      * @link https://laravel.com/docs/11.x/validation#rule-not-in
-     * @param Arrayable<array-key, mixed>|array<array-key, mixed>|string $values
+     * @param Arrayable<array-key, BackedEnum|UnitEnum|string>|array<BackedEnum|UnitEnum|string>|BackedEnum|UnitEnum|string $values
      */
-    public function notIn(Arrayable|array|string $values): self
+    public function notIn(Arrayable|BackedEnum|UnitEnum|array|string $values): self
     {
         return $this->rule(Rule::notIn($values));
     }

--- a/tests/Unit/RuleTest.php
+++ b/tests/Unit/RuleTest.php
@@ -1150,6 +1150,24 @@ class RuleTest extends TestCase
                 ],
                 'fails' => true,
             ],
+            'in enum valid' => [
+                'data' => [
+                    'field-a' => ExampleStringEnum::Valid->value,
+                ],
+                'rules' => fn() => [
+                    'field-a' => RuleSet::create()->in(ExampleStringEnum::Valid),
+                ],
+                'fails' => false,
+            ],
+            'in enum invalid' => [
+                'data' => [
+                    'field-a' => ExampleStringEnum::Another->value,
+                ],
+                'rules' => fn() => [
+                    'field-a' => RuleSet::create()->in(ExampleStringEnum::Valid),
+                ],
+                'fails' => true,
+            ],
             'inArray valid' => [
                 'data' => [
                     'field-a' => 'a',
@@ -1661,6 +1679,24 @@ class RuleTest extends TestCase
                 ],
                 'rules' => fn() => [
                     'field-a' => RuleSet::create()->notIn(['a', 'b', 'c']),
+                ],
+                'fails' => true,
+            ],
+            'notIn enum valid' => [
+                'data' => [
+                    'field-a' => ExampleStringEnum::Another->value,
+                ],
+                'rules' => fn() => [
+                    'field-a' => RuleSet::create()->notIn(ExampleStringEnum::Valid),
+                ],
+                'fails' => false,
+            ],
+            'notIn enum invalid' => [
+                'data' => [
+                    'field-a' => ExampleStringEnum::Valid->value,
+                ],
+                'rules' => fn() => [
+                    'field-a' => RuleSet::create()->notIn(ExampleStringEnum::Valid),
                 ],
                 'fails' => true,
             ],


### PR DESCRIPTION
The `in`/`notIn` rules were typed incorrectly compared to what Laravel was type hinted as supporting.

It is still typed a little oddly, any maybe wrong depending on how you interpret it. Laravel's [internal rule](https://github.com/laravel/framework/blob/11.x/src/Illuminate/Validation/Rules/In.php#L38) will use func_get_args if not passed an array, but we do not do the same.  I am not sure how we want to handle it, so for now I am just bringing the expected types in line with Laravel.  We may want to use the same pattern, or add `...$values` to come closer to supporting the default of `in($valueA, $valueB, ...)`.

---

There were also some rules that were added before the docs site had been updated which were missing the links, this adds them and updates the text to match the docs.