### PR TITLE
Add enum support for defined rule set names

### DIFF
--- a/src/Contracts/DefinedRuleSets.php
+++ b/src/Contracts/DefinedRuleSets.php
@@ -4,11 +4,13 @@ declare(strict_types=1);
 
 namespace Sourcetoad\RuleHelper\Contracts;
 
+use BackedEnum;
 use Sourcetoad\RuleHelper\RuleSet;
+use UnitEnum;
 
 interface DefinedRuleSets
 {
-    public function define(string $name, RuleSet $ruleSet): void;
+    public function define(string|BackedEnum|UnitEnum $name, RuleSet $ruleSet): void;
 
-    public function useDefined(string $name): RuleSet;
+    public function useDefined(string|BackedEnum|UnitEnum $name): RuleSet;
 }

--- a/src/DefinedRuleSets.php
+++ b/src/DefinedRuleSets.php
@@ -4,22 +4,43 @@ declare(strict_types=1);
 
 namespace Sourcetoad\RuleHelper;
 
+use BackedEnum;
+use InvalidArgumentException;
+use UnitEnum;
+
 class DefinedRuleSets implements Contracts\DefinedRuleSets
 {
     /** @var array<string, RuleSet> */
     private array $definedRules = [];
 
-    public function define(string $name, RuleSet $ruleSet): void
+    public function define(string|BackedEnum|UnitEnum $name, RuleSet $ruleSet): void
     {
-        $this->definedRules[$name] = $ruleSet;
+        $key = $this->getKey($name);
+
+        $this->definedRules[$key] = $ruleSet;
     }
 
-    public function useDefined(string $name): RuleSet
+    public function useDefined(string|BackedEnum|UnitEnum $name): RuleSet
     {
-        if (!array_key_exists($name, $this->definedRules)) {
-            throw new \InvalidArgumentException('No rule defined with name '.$name);
+        $key = $this->getKey($name);
+
+        if (!array_key_exists($key, $this->definedRules)) {
+            throw new InvalidArgumentException('No rule defined with name '.$key);
         }
 
-        return $this->definedRules[$name];
+        return $this->definedRules[$key];
+    }
+
+    private function getKey(string|BackedEnum|UnitEnum $value): string
+    {
+        if ($value instanceof UnitEnum) {
+            return sprintf(
+                '%s::%s',
+                $value::class,
+                $value instanceof BackedEnum ? $value->value : $value->name,
+            );
+        }
+
+        return $value;
     }
 }

--- a/src/RuleSet.php
+++ b/src/RuleSet.php
@@ -64,7 +64,7 @@ class RuleSet implements Arrayable, IteratorAggregate
     /**
      * Defines a rule set to be re-used later.
      */
-    public static function define(string $name, RuleSet $ruleSet): void
+    public static function define(string|BackedEnum|UnitEnum $name, RuleSet $ruleSet): void
     {
         static::getDefinedRuleSets()->define($name, $ruleSet);
     }
@@ -72,7 +72,7 @@ class RuleSet implements Arrayable, IteratorAggregate
     /**
      * Uses a previously defined rule set.
      */
-    public static function useDefined(string $name): RuleSet
+    public static function useDefined(string|BackedEnum|UnitEnum $name): RuleSet
     {
         return static::getDefinedRuleSets()->useDefined($name);
     }

--- a/tests/Stubs/ExampleNonBackedEnum.php
+++ b/tests/Stubs/ExampleNonBackedEnum.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sourcetoad\RuleHelper\Tests\Stubs;
+
+enum ExampleNonBackedEnum
+{
+    case Value;
+}

--- a/tests/Stubs/ExampleStringDuplicateEnum.php
+++ b/tests/Stubs/ExampleStringDuplicateEnum.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sourcetoad\RuleHelper\Tests\Stubs;
+
+enum ExampleStringDuplicateEnum: string
+{
+    case Another = 'another';
+}

--- a/tests/Unit/DefinedRuleSetsTest.php
+++ b/tests/Unit/DefinedRuleSetsTest.php
@@ -9,6 +9,9 @@ use Illuminate\Support\Facades\Validator;
 use Sourcetoad\RuleHelper\Contracts\DefinedRuleSets;
 use Sourcetoad\RuleHelper\RuleHelperServiceProvider;
 use Sourcetoad\RuleHelper\RuleSet;
+use Sourcetoad\RuleHelper\Tests\Stubs\ExampleNonBackedEnum;
+use Sourcetoad\RuleHelper\Tests\Stubs\ExampleStringDuplicateEnum;
+use Sourcetoad\RuleHelper\Tests\Stubs\ExampleStringEnum;
 use Sourcetoad\RuleHelper\Tests\TestCase;
 
 class DefinedRuleSetsTest extends TestCase
@@ -87,5 +90,32 @@ class DefinedRuleSetsTest extends TestCase
 
         // Assert
         $this->assertSame(['required', 'email'], $ruleSet->toArray());
+    }
+
+    public function testWorksWithNonBackedEnums(): void
+    {
+        // Arrange
+        RuleSet::define(ExampleNonBackedEnum::Value, RuleSet::create()->email());
+
+        // Act
+        $ruleSet = RuleSet::useDefined(ExampleNonBackedEnum::Value);
+
+        // Assert
+        $this->assertSame(['email'], $ruleSet->toArray());
+    }
+
+    public function testDefinedEnumsWithDuplicateValuesAreTreatedAsDifferent(): void
+    {
+        // Arrange
+        RuleSet::define(ExampleStringEnum::Another, RuleSet::create()->email());
+        RuleSet::define(ExampleStringDuplicateEnum::Another, RuleSet::create()->required());
+
+        // Act
+        $ruleSetOne = RuleSet::useDefined(ExampleStringEnum::Another);
+        $ruleSetTwo = RuleSet::useDefined(ExampleStringDuplicateEnum::Another);
+
+        // Assert
+        $this->assertSame(['email'], $ruleSetOne->toArray());
+        $this->assertSame(['required'], $ruleSetTwo->toArray());
     }
 }


### PR DESCRIPTION
In case people want to avoid magic strings by using an enum to contain their defined rule sets.