### PR TITLE
Confirmation field override

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -2,6 +2,10 @@
 
 ## v5
 
+### Upgrading from v5.2 to v5.3
+
+- Minimum Laravel version increased from `11.8` to `11.23.2`.
+
 ### Upgrading from v5.1 to v5.2
 
 - Minimum Laravel version increased from `11.5` to `11.8`.

--- a/composer.json
+++ b/composer.json
@@ -6,11 +6,11 @@
     "minimum-stability": "stable",
     "require": {
         "php": "^8.2",
-        "laravel/framework": "^11.8"
+        "laravel/framework": "^11.23.2"
     },
     "require-dev": {
         "ext-json": "*",
-        "orchestra/testbench": "^9.0",
+        "orchestra/testbench": "^9.4",
         "phpunit/phpunit": "^10.5",
         "laravel/pint": "1.13.9",
         "larastan/larastan": "^2.0"

--- a/src/Rule.php
+++ b/src/Rule.php
@@ -203,8 +203,12 @@ class Rule
      *
      * @link https://laravel.com/docs/11.x/validation#rule-confirmed
      */
-    public static function confirmed(): string
+    public static function confirmed(?string $confirmationFieldName = null): string
     {
+        if ($confirmationFieldName !== null) {
+            return 'confirmed:'.$confirmationFieldName;
+        }
+
         return 'confirmed';
     }
 

--- a/src/RuleSet.php
+++ b/src/RuleSet.php
@@ -273,9 +273,9 @@ class RuleSet implements Arrayable, IteratorAggregate
      *
      * @link https://laravel.com/docs/11.x/validation#rule-confirmed
      */
-    public function confirmed(): self
+    public function confirmed(?string $confirmationFieldName = null): self
     {
-        return $this->rule(Rule::confirmed());
+        return $this->rule(Rule::confirmed($confirmationFieldName));
     }
 
     /**

--- a/tests/Unit/RuleTest.php
+++ b/tests/Unit/RuleTest.php
@@ -519,6 +519,28 @@ class RuleTest extends TestCase
                 ],
                 'fails' => true,
             ],
+            'confirmed with override valid' => [
+                'data' => [
+                    'field' => 'value',
+                    'fieldConfirmation' => 'value',
+                    'field_confirmation' => 'other-value',
+                ],
+                'rules' => fn() => [
+                    'field' => RuleSet::create()->confirmed('fieldConfirmation'),
+                ],
+                'fails' => false,
+            ],
+            'confirmed with override invalid' => [
+                'data' => [
+                    'field' => 'value',
+                    'fieldConfirmation' => 'other-value',
+                    'field_confirmation' => 'value',
+                ],
+                'rules' => fn() => [
+                    'field' => RuleSet::create()->confirmed('fieldConfirmation'),
+                ],
+                'fails' => true,
+            ],
             'contains valid' => [
                 'data' => [
                     'field' => ['a', 'b', 'c'],


### PR DESCRIPTION
The ability to override the confirmation field name was added in 11.23, this adds support for it.