### PR TITLE
Type fixes

### DIFF
--- a/src/Rule.php
+++ b/src/Rule.php
@@ -339,7 +339,7 @@ class Rule
      * like *3/2* or a float like *1.5*.
      *
      * @link https://laravel.com/docs/11.x/validation#rule-dimensions
-     * @param array<string, int|float> $constraints
+     * @param array<string, int|float|string> $constraints
      */
     public static function dimensions(array $constraints = []): Dimensions
     {

--- a/src/RuleSet.php
+++ b/src/RuleSet.php
@@ -502,7 +502,7 @@ class RuleSet implements Arrayable, IteratorAggregate
      * methods if a true boolean is passed in or the passed in closure returns true.
      *
      * @link https://laravel.com/docs/11.x/validation#rule-exclude-if
-     * @param callable|bool $callback
+     * @param bool|callable(): bool $callback
      */
     public function excludeIf(mixed $callback): self
     {

--- a/src/RuleSet.php
+++ b/src/RuleSet.php
@@ -404,7 +404,7 @@ class RuleSet implements Arrayable, IteratorAggregate
      * pass a callback which accepts a {@see \Illuminate\Validation\Rules\Dimensions} instance.
      *
      * @link https://laravel.com/docs/11.x/validation#rule-dimensions
-     * @param array<string, int|float> $constraints
+     * @param array<string, int|float|string> $constraints
      * @param ?callable(\Illuminate\Validation\Rules\Dimensions): (\Illuminate\Validation\Rules\Dimensions|void) $modifier
      */
     public function dimensions(array $constraints = [], ?callable $modifier = null): self

--- a/src/RuleSet.php
+++ b/src/RuleSet.php
@@ -405,14 +405,14 @@ class RuleSet implements Arrayable, IteratorAggregate
      *
      * @link https://laravel.com/docs/11.x/validation#rule-dimensions
      * @param array<string, int|float> $constraints
-     * @param ?callable(\Illuminate\Validation\Rules\Dimensions): void $modifier
+     * @param ?callable(\Illuminate\Validation\Rules\Dimensions): (\Illuminate\Validation\Rules\Dimensions|void) $modifier
      */
     public function dimensions(array $constraints = [], ?callable $modifier = null): self
     {
         $rule = Rule::dimensions($constraints);
 
         if ($modifier) {
-            $modifier($rule);
+            $rule = $this->modify($rule, $modifier);
         }
 
         return $this->rule($rule);
@@ -473,14 +473,14 @@ class RuleSet implements Arrayable, IteratorAggregate
      *
      * @link https://laravel.com/docs/11.x/validation#rule-enum
      * @param class-string $type
-     * @param ?callable(\Illuminate\Validation\Rules\Enum): void $modifier
+     * @param ?callable(\Illuminate\Validation\Rules\Enum): (\Illuminate\Validation\Rules\Enum|void) $modifier
      */
     public function enum(string $type, ?callable $modifier = null): self
     {
         $rule = Rule::enum($type);
 
         if ($modifier) {
-            $modifier($rule);
+            $rule = $this->modify($rule, $modifier);
         }
 
         return $this->rule($rule);
@@ -562,14 +562,14 @@ class RuleSet implements Arrayable, IteratorAggregate
      * {@see RuleSet::rule} or pass a callback which accepts an {@see \Illuminate\Validation\Rules\Exists} instance.
      *
      * @link https://laravel.com/docs/11.x/validation#rule-exists
-     * @param ?callable(\Illuminate\Validation\Rules\Exists): void $modifier
+     * @param ?callable(\Illuminate\Validation\Rules\Exists): (\Illuminate\Validation\Rules\Exists|void) $modifier
      */
     public function exists(string $table, string $column = 'NULL', ?callable $modifier = null): self
     {
         $rule = Rule::exists($table, $column);
 
         if ($modifier) {
-            $modifier($rule);
+            $rule = $this->modify($rule, $modifier);
         }
 
         return $this->rule($rule);
@@ -951,14 +951,14 @@ class RuleSet implements Arrayable, IteratorAggregate
      * use {@see Rule::password} with {@see RuleSet::rule}, or pass a callback which accepts a {@see Password} instance.
      *
      * @link https://laravel.com/docs/11.x/validation#validating-passwords
-     * @param ?callable(\Illuminate\Validation\Rules\Password): void $modifier
+     * @param ?callable(\Illuminate\Validation\Rules\Password): (\Illuminate\Validation\Rules\Password|void) $modifier
      */
     public function password(?int $size = null, ?callable $modifier = null): self
     {
         $rule = Rule::password($size);
 
         if ($modifier) {
-            $modifier($rule);
+            $rule = $this->modify($rule, $modifier);
         }
 
         return $this->rule($rule);
@@ -1294,14 +1294,14 @@ class RuleSet implements Arrayable, IteratorAggregate
      * {@see RuleSet::rule} or pass a callback which accepts a {@see \Illuminate\Validation\Rules\Unique} instance.
      *
      * @link https://laravel.com/docs/11.x/validation#rule-unique
-     * @param ?callable(\Illuminate\Validation\Rules\Unique): void $modifier
+     * @param ?callable(\Illuminate\Validation\Rules\Unique): (\Illuminate\Validation\Rules\Unique|void) $modifier
      */
     public function unique(string $table, string $column = 'NULL', ?callable $modifier = null): self
     {
         $rule = Rule::unique($table, $column);
 
         if ($modifier) {
-            $modifier($rule);
+            $rule = $this->modify($rule, $modifier);
         }
 
         return $this->rule($rule);
@@ -1352,5 +1352,17 @@ class RuleSet implements Arrayable, IteratorAggregate
     protected static function getDefinedRuleSets(): Contracts\DefinedRuleSets
     {
         return resolve(Contracts\DefinedRuleSets::class);
+    }
+
+    /**
+     * @param T $rule
+     * @param callable(T): (T|void) $modifier
+     * @return T
+     * @template T
+     */
+    protected function modify($rule, callable $modifier)
+    {
+        /** @var T */
+        return $modifier($rule) ?: $rule;
     }
 }

--- a/tests/Unit/RuleTest.php
+++ b/tests/Unit/RuleTest.php
@@ -9,12 +9,12 @@ use Carbon\CarbonImmutable;
 use Closure;
 use DateTime;
 use Illuminate\Auth\AuthManager;
-use Illuminate\Contracts\Auth\Access\Gate;
 use Illuminate\Contracts\Auth\Guard;
 use Illuminate\Contracts\Hashing\Hasher;
 use Illuminate\Contracts\Validation\InvokableRule;
 use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Foundation\Auth\User;
+use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Support\Str;
 use Illuminate\Validation\Rules\Dimensions;
@@ -478,7 +478,11 @@ class RuleTest extends TestCase
                 'data' => 'value-a',
                 'rules' => function () {
                     $mockUser = new User;
-                    $this->mockGateAllows(true, 'modify', [User::class, $mockUser, 'value-a']);
+
+                    Gate::expects('allows')
+                        ->once()
+                        ->with('modify', [User::class, $mockUser, 'value-a'])
+                        ->andReturn(true);
 
                     return RuleSet::create()->can('modify', User::class, $mockUser);
                 },
@@ -488,7 +492,11 @@ class RuleTest extends TestCase
                 'data' => 'value-b',
                 'rules' => function () {
                     $mockUser = new User;
-                    $this->mockGateAllows(false, 'modify', [User::class, $mockUser, 'value-b']);
+
+                    Gate::expects('allows')
+                        ->once()
+                        ->with('modify', [User::class, $mockUser, 'value-b'])
+                        ->andReturn(false);
 
                     return RuleSet::create()->can('modify', User::class, $mockUser);
                 },
@@ -3113,19 +3121,5 @@ class RuleTest extends TestCase
                 return $this->extension;
             }
         };
-    }
-
-    private function mockGateAllows(bool $return, ...$arguments): void
-    {
-        $gate = $this->mock(Gate::class);
-
-        $gate
-            ->expects('allows')
-            ->once()
-            ->with(...$arguments)
-            ->andReturn($return)
-            ->getMock();
-
-        $this->app->instance(Gate::class, $gate);
     }
 }

--- a/tests/Unit/RuleTest.php
+++ b/tests/Unit/RuleTest.php
@@ -40,7 +40,7 @@ class RuleTest extends TestCase
     }
 
     #[DataProvider('ruleDataProvider')]
-    public function testRuleIntegration($data, Closure $rules, bool $fails, ?array $errors = null): void
+    public function testRuleIntegration(mixed $data, Closure $rules, bool $fails, ?array $errors = null): void
     {
         // Arrange
         if ($data instanceof Closure) {


### PR DESCRIPTION
When I was adding more explicit typing for the modifier callbacks I typed them as void since we didn't use the result in the functions. This left existing code that used the modifier with an arrow function producing static analysis errors since they return the rule from the function. To fix it I made the modifier argument support functions that return void or the expected rule, then treat it as mutable when void is returned and replace the rule when not (most rules are mutable so this will have no effect in most cases, it is just in case someone replaces completely in the modifier).