### PR TITLE
Next version

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ composer require sourcetoad/rule-helper-for-laravel
 
 ### RuleSet
 
-The `RuleSet` class provides a fluent interface for defining sets of rules. 
+The `RuleSet` class provides a fluent interface for defining sets of rules.
 
 #### Basic usage
 
@@ -108,3 +108,14 @@ Accepts multiple `RequiredIf` rules and only marks as required if all return tru
 #### requiredIfAny
 
 Accepts multiple `RequiredIf` rules and marks as required if any return true.
+
+## Version Compatibility
+
+| Laravel | Rule Helper |
+|---------|-------------|
+| 12.x    | 6.x         |
+| 11.x    | 5.x         |
+| 10.x    | 4.x         |
+| 9.x     | 3.x         |
+| 9.x     | 2.x         |
+| 8.x     | 1.x         |

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,13 @@
 # Upgrade Guide
 
+## v6
+
+### Upgrading from v5.6 to v6.0
+
+- Minimum Laravel version increased from `11.43` to `12.0`.
+- `Rule::date`, `Rule::email`, `Rule::file`, and `Rule::image` now return the fluent interface instead of a string. The
+  `RuleSet` variant now accepts a modifier callback.
+
 ## v5
 
 ### Upgrading from v5.5 to v5.6

--- a/composer.json
+++ b/composer.json
@@ -3,16 +3,17 @@
     "description": "Rule helper for Laravel",
     "type": "library",
     "license": "MIT",
-    "minimum-stability": "stable",
+    "minimum-stability": "dev",
     "require": {
         "php": "^8.2||^8.3||^8.4",
-        "laravel/framework": "^11.43"
+        "laravel/framework": "^12.0.x-dev"
     },
     "require-dev": {
         "ext-json": "*",
-        "orchestra/testbench": "^9.4",
-        "phpunit/phpunit": "^10.5",
-        "laravel/pint": "1.19.0",
+        "nunomaduro/collision": "8.6.1",
+        "orchestra/testbench": "^10.0.x-dev",
+        "phpunit/phpunit": "^11.5",
+        "laravel/pint": "1.21",
         "larastan/larastan": "^3.0"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -3,15 +3,14 @@
     "description": "Rule helper for Laravel",
     "type": "library",
     "license": "MIT",
-    "minimum-stability": "dev",
+    "minimum-stability": "stable",
     "require": {
         "php": "^8.2||^8.3||^8.4",
-        "laravel/framework": "^12.0.x-dev"
+        "laravel/framework": "^12.0"
     },
     "require-dev": {
         "ext-json": "*",
-        "nunomaduro/collision": "8.6.1",
-        "orchestra/testbench": "^10.0.x-dev",
+        "orchestra/testbench": "^10.0",
         "phpunit/phpunit": "^11.5",
         "laravel/pint": "1.21",
         "larastan/larastan": "^3.0"

--- a/src/Rule.php
+++ b/src/Rule.php
@@ -18,6 +18,7 @@ use Illuminate\Validation\Rules\ArrayRule;
 use Illuminate\Validation\Rules\Can;
 use Illuminate\Validation\Rules\Date;
 use Illuminate\Validation\Rules\Dimensions;
+use Illuminate\Validation\Rules\Email;
 use Illuminate\Validation\Rules\Enum;
 use Illuminate\Validation\Rules\ExcludeIf;
 use Illuminate\Validation\Rules\Exists;
@@ -440,24 +441,11 @@ class Rule
     /**
      * The field under validation must be formatted as an email address.
      *
-     * By default, the *RFCValidation* validator is applied, but you can apply other validation styles as well:
-     *
-     * - *rfc*: {@see \Egulias\EmailValidator\Validation\RFCValidation}
-     * - *strict*: {@see \Egulias\EmailValidator\Validation\NoRFCWarningsValidation}
-     * - *dns*: {@see \Egulias\EmailValidator\Validation\DNSCheckValidation}
-     * - *spoof*: {@see \Egulias\EmailValidator\Validation\Extra\SpoofCheckValidation}
-     * - *filter*: {@see \Illuminate\Validation\Concerns\FilterEmailValidation}
-     * - *filter_unicode*: {@see \Illuminate\Validation\Concerns\FilterEmailValidation::unicode}
-     *
      * @link https://laravel.com/docs/11.x/validation#rule-email
      */
-    public static function email(string ...$validator): string
+    public static function email(): Email
     {
-        if (count($validator)) {
-            return 'email:'.implode(',', $validator);
-        }
-
-        return 'email';
+        return LaravelRule::email();
     }
 
     /**

--- a/src/Rule.php
+++ b/src/Rule.php
@@ -16,6 +16,7 @@ use Illuminate\Validation\ConditionalRules;
 use Illuminate\Validation\Rule as LaravelRule;
 use Illuminate\Validation\Rules\ArrayRule;
 use Illuminate\Validation\Rules\Can;
+use Illuminate\Validation\Rules\Date;
 use Illuminate\Validation\Rules\Dimensions;
 use Illuminate\Validation\Rules\Enum;
 use Illuminate\Validation\Rules\ExcludeIf;
@@ -289,9 +290,9 @@ class Rule
      *
      * @link https://laravel.com/docs/11.x/validation#rule-date
      */
-    public static function date(): string
+    public static function date(): Date
     {
-        return 'date';
+        return LaravelRule::date();
     }
 
     /**

--- a/src/Rule.php
+++ b/src/Rule.php
@@ -22,6 +22,7 @@ use Illuminate\Validation\Rules\Email;
 use Illuminate\Validation\Rules\Enum;
 use Illuminate\Validation\Rules\ExcludeIf;
 use Illuminate\Validation\Rules\Exists;
+use Illuminate\Validation\Rules\File;
 use Illuminate\Validation\Rules\In;
 use Illuminate\Validation\Rules\NotIn;
 use Illuminate\Validation\Rules\Password;
@@ -576,9 +577,9 @@ class Rule
      *
      * @link https://laravel.com/docs/11.x/validation#rule-file
      */
-    public static function file(): string
+    public static function file(): File
     {
-        return 'file';
+        return LaravelRule::file();
     }
 
     /**

--- a/src/Rule.php
+++ b/src/Rule.php
@@ -23,6 +23,7 @@ use Illuminate\Validation\Rules\Enum;
 use Illuminate\Validation\Rules\ExcludeIf;
 use Illuminate\Validation\Rules\Exists;
 use Illuminate\Validation\Rules\File;
+use Illuminate\Validation\Rules\ImageFile;
 use Illuminate\Validation\Rules\In;
 use Illuminate\Validation\Rules\NotIn;
 use Illuminate\Validation\Rules\Password;
@@ -632,9 +633,9 @@ class Rule
      *
      * @link https://laravel.com/docs/11.x/validation#rule-image
      */
-    public static function image(): string
+    public static function image(): ImageFile
     {
-        return 'image';
+        return LaravelRule::imageFile();
     }
 
     /**

--- a/src/RuleSet.php
+++ b/src/RuleSet.php
@@ -660,10 +660,17 @@ class RuleSet implements Arrayable, IteratorAggregate
      * The field under validation must be a successfully uploaded file.
      *
      * @link https://laravel.com/docs/11.x/validation#rule-file
+     * @param ?callable(\Illuminate\Validation\Rules\File): (\Illuminate\Validation\Rules\File|void) $modifier
      */
-    public function file(): self
+    public function file(?callable $modifier = null): self
     {
-        return $this->rule(Rule::file());
+        $rule = Rule::file();
+
+        if ($modifier) {
+            $rule = $this->modify($rule, $modifier);
+        }
+
+        return $this->rule($rule);
     }
 
     /**

--- a/src/RuleSet.php
+++ b/src/RuleSet.php
@@ -498,20 +498,18 @@ class RuleSet implements Arrayable, IteratorAggregate
     /**
      * The field under validation must be formatted as an email address.
      *
-     * By default, the *RFCValidation* validator is applied, but you can apply other validation styles as well:
-     *
-     * - *rfc*: {@see \Egulias\EmailValidator\Validation\RFCValidation}
-     * - *strict*: {@see \Egulias\EmailValidator\Validation\NoRFCWarningsValidation}
-     * - *dns*: {@see \Egulias\EmailValidator\Validation\DNSCheckValidation}
-     * - *spoof*: {@see \Egulias\EmailValidator\Validation\Extra\SpoofCheckValidation}
-     * - *filter*: {@see \Illuminate\Validation\Concerns\FilterEmailValidation}
-     * - *filter_unicode*: {@see \Illuminate\Validation\Concerns\FilterEmailValidation::unicode}
-     *
      * @link https://laravel.com/docs/11.x/validation#rule-email
+     * @param ?callable(\Illuminate\Validation\Rules\Email): (\Illuminate\Validation\Rules\Email|void) $modifier
      */
-    public function email(string ...$validator): self
+    public function email(?callable $modifier = null): self
     {
-        return $this->rule(Rule::email(...$validator));
+        $rule = Rule::email();
+
+        if ($modifier) {
+            $rule = $this->modify($rule, $modifier);
+        }
+
+        return $this->rule($rule);
     }
 
     /**

--- a/src/RuleSet.php
+++ b/src/RuleSet.php
@@ -338,10 +338,17 @@ class RuleSet implements Arrayable, IteratorAggregate
      * The field under validation must be a valid, non-relative date according to the *strtotime* PHP function.
      *
      * @link https://laravel.com/docs/11.x/validation#rule-date
+     * @param ?callable(\Illuminate\Validation\Rules\Date): (\Illuminate\Validation\Rules\Date|void) $modifier
      */
-    public function date(): self
+    public function date(?callable $modifier = null): self
     {
-        return $this->rule(Rule::date());
+        $rule = Rule::date();
+
+        if ($modifier) {
+            $rule = $this->modify($rule, $modifier);
+        }
+
+        return $this->rule($rule);
     }
 
     /**

--- a/src/RuleSet.php
+++ b/src/RuleSet.php
@@ -722,10 +722,17 @@ class RuleSet implements Arrayable, IteratorAggregate
      * The file under validation must be an image (jpg, jpeg, png, bmp, gif, svg, or webp).
      *
      * @link https://laravel.com/docs/11.x/validation#rule-image
+     * @param ?callable(\Illuminate\Validation\Rules\ImageFile): (\Illuminate\Validation\Rules\ImageFile|void) $modifier
      */
-    public function image(): self
+    public function image(?callable $modifier = null): self
     {
-        return $this->rule(Rule::image());
+        $rule = Rule::image();
+
+        if ($modifier) {
+            $rule = $this->modify($rule, $modifier);
+        }
+
+        return $this->rule($rule);
     }
 
     /**

--- a/tests/Unit/DefinedRuleSetsTest.php
+++ b/tests/Unit/DefinedRuleSetsTest.php
@@ -28,10 +28,10 @@ class DefinedRuleSetsTest extends TestCase
     public function testCanUseRulesDefinedOutsideOfCurrentRuleSet(): void
     {
         // Arrange
-        resolve(DefinedRuleSets::class)->define('user.email', RuleSet::create()->email());
+        resolve(DefinedRuleSets::class)->define('user.email', RuleSet::create()->string());
 
         $validator = Validator::make([
-            'field-a' => $this->faker->name(),
+            'field-a' => $this->faker->randomNumber(),
         ], [
             'field-a' => RuleSet::useDefined('user.email'),
         ]);
@@ -42,7 +42,7 @@ class DefinedRuleSetsTest extends TestCase
 
         // Assert
         $this->assertTrue($fails, 'Failed asserting that RuleSet used defined rule.');
-        $this->assertEquals(['field-a' => ['The field-a field must be a valid email address.']], $messages->toArray());
+        $this->assertEquals(['field-a' => ['The field-a field must be a string.']], $messages->toArray());
     }
 
     public function testModifyingDuringUseDoesNotModifyStoredCopy(): void
@@ -83,31 +83,31 @@ class DefinedRuleSetsTest extends TestCase
     public function testConcatDefinedRuleSet(): void
     {
         // Arrange
-        RuleSet::define('user.email', RuleSet::create()->email());
+        RuleSet::define('user.email', RuleSet::create()->string());
 
         // Act
         $ruleSet = RuleSet::create()->required()->concatDefined('user.email');
 
         // Assert
-        $this->assertSame(['required', 'email'], $ruleSet->toArray());
+        $this->assertSame(['required', 'string'], $ruleSet->toArray());
     }
 
     public function testWorksWithNonBackedEnums(): void
     {
         // Arrange
-        RuleSet::define(ExampleNonBackedEnum::Value, RuleSet::create()->email());
+        RuleSet::define(ExampleNonBackedEnum::Value, RuleSet::create()->string());
 
         // Act
         $ruleSet = RuleSet::useDefined(ExampleNonBackedEnum::Value);
 
         // Assert
-        $this->assertSame(['email'], $ruleSet->toArray());
+        $this->assertSame(['string'], $ruleSet->toArray());
     }
 
     public function testDefinedEnumsWithDuplicateValuesAreTreatedAsDifferent(): void
     {
         // Arrange
-        RuleSet::define(ExampleStringEnum::Another, RuleSet::create()->email());
+        RuleSet::define(ExampleStringEnum::Another, RuleSet::create()->string());
         RuleSet::define(ExampleStringDuplicateEnum::Another, RuleSet::create()->required());
 
         // Act
@@ -115,7 +115,7 @@ class DefinedRuleSetsTest extends TestCase
         $ruleSetTwo = RuleSet::useDefined(ExampleStringDuplicateEnum::Another);
 
         // Assert
-        $this->assertSame(['email'], $ruleSetOne->toArray());
+        $this->assertSame(['string'], $ruleSetOne->toArray());
         $this->assertSame(['required'], $ruleSetTwo->toArray());
     }
 }

--- a/tests/Unit/RuleTest.php
+++ b/tests/Unit/RuleTest.php
@@ -19,6 +19,7 @@ use Illuminate\Support\Facades\Validator;
 use Illuminate\Support\Str;
 use Illuminate\Validation\Rules\Date;
 use Illuminate\Validation\Rules\Dimensions;
+use Illuminate\Validation\Rules\Email;
 use Illuminate\Validation\Rules\Enum;
 use Illuminate\Validation\Rules\Password;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -1078,52 +1079,52 @@ class RuleTest extends TestCase
             ],
             'email rfc valid' => [
                 'data' => 'someone@example.com',
-                'rules' => fn() => RuleSet::create()->email('rfc'),
+                'rules' => fn() => RuleSet::create()->email(fn(Email $rule) => $rule->rfcCompliant()),
                 'fails' => false,
             ],
             'email rfc invalid' => [
                 'data' => 'someone',
-                'rules' => fn() => RuleSet::create()->email('rfc'),
+                'rules' => fn() => RuleSet::create()->email(fn(Email $rule) => $rule->rfcCompliant()),
                 'fails' => true,
             ],
             'email strict valid' => [
                 'data' => 'someone@example.com',
-                'rules' => fn() => RuleSet::create()->email('strict'),
+                'rules' => fn() => RuleSet::create()->email(fn(Email $rule) => $rule->strict()),
                 'fails' => false,
             ],
             'email strict invalid' => [
                 'data' => 'someone@'.Str::repeat('example', 100).'.com',
-                'rules' => fn() => RuleSet::create()->email('strict'),
+                'rules' => fn() => RuleSet::create()->email(fn(Email $rule) => $rule->strict()),
                 'fails' => true,
             ],
             'email dns valid' => [
                 'data' => 'someone@gmail.com',
-                'rules' => fn() => RuleSet::create()->email('dns'),
+                'rules' => fn() => RuleSet::create()->email(fn(Email $rule) => $rule->validateMxRecord()),
                 'fails' => false,
             ],
             'email dns invalid' => [
                 'data' => 'someone@'.Str::repeat(Str::uuid()->toString(), 3).'.com',
-                'rules' => fn() => RuleSet::create()->email('dns'),
+                'rules' => fn() => RuleSet::create()->email(fn(Email $rule) => $rule->validateMxRecord()),
                 'fails' => true,
             ],
             'email spoof valid' => [
                 'data' => 'someone@gmail.com',
-                'rules' => fn() => RuleSet::create()->email('spoof'),
+                'rules' => fn() => RuleSet::create()->email(fn(Email $rule) => $rule->preventSpoofing()),
                 'fails' => false,
             ],
             'email spoof invalid' => [
                 'data' => "someone@\u{0430}pple.com",
-                'rules' => fn() => RuleSet::create()->email('spoof'),
+                'rules' => fn() => RuleSet::create()->email(fn(Email $rule) => $rule->preventSpoofing()),
                 'fails' => true,
             ],
             'email filter valid' => [
                 'data' => 'someone@gmail.com',
-                'rules' => fn() => RuleSet::create()->email('filter'),
+                'rules' => fn() => RuleSet::create()->email(fn(Email $rule) => $rule->withNativeValidation()),
                 'fails' => false,
             ],
             'email filter invalid' => [
                 'data' => 'someone@com',
-                'rules' => fn() => RuleSet::create()->email('filter'),
+                'rules' => fn() => RuleSet::create()->email(fn(Email $rule) => $rule->withNativeValidation()),
                 'fails' => true,
             ],
             'endsWith valid' => [

--- a/tests/Unit/RuleTest.php
+++ b/tests/Unit/RuleTest.php
@@ -22,6 +22,7 @@ use Illuminate\Validation\Rules\Dimensions;
 use Illuminate\Validation\Rules\Email;
 use Illuminate\Validation\Rules\Enum;
 use Illuminate\Validation\Rules\File as FileRule;
+use Illuminate\Validation\Rules\ImageFile;
 use Illuminate\Validation\Rules\Password;
 use PHPUnit\Framework\Attributes\DataProvider;
 use Sourcetoad\RuleHelper\Rule;
@@ -1361,6 +1362,16 @@ class RuleTest extends TestCase
             'image invalid' => [
                 'data' => fn() => $this->mockFile('/code/document.pdf'),
                 'rules' => fn() => RuleSet::create()->image(),
+                'fails' => true,
+            ],
+            'image fluent valid' => [
+                'data' => new File(dirname(__DIR__).'/Stubs/100x50.png'),
+                'rules' => fn() => RuleSet::create()->image(fn(ImageFile $rule) => $rule->dimensions(Rule::dimensions(['min_width' => 100]))),
+                'fails' => false,
+            ],
+            'image fluent invalid' => [
+                'data' => new File(dirname(__DIR__).'/Stubs/100x50.png'),
+                'rules' => fn() => RuleSet::create()->image(fn(ImageFile $rule) => $rule->dimensions(Rule::dimensions(['min_width' => 150]))),
                 'fails' => true,
             ],
             'in valid' => [

--- a/tests/Unit/RuleTest.php
+++ b/tests/Unit/RuleTest.php
@@ -41,6 +41,7 @@ class RuleTest extends TestCase
         parent::setUp();
 
         Password::$defaultCallback = null;
+        MimeTypes::setDefault(new MimeTypes);
     }
 
     #[DataProvider('ruleDataProvider')]

--- a/tests/Unit/RuleTest.php
+++ b/tests/Unit/RuleTest.php
@@ -17,6 +17,7 @@ use Illuminate\Foundation\Auth\User;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Support\Str;
+use Illuminate\Validation\Rules\Date;
 use Illuminate\Validation\Rules\Dimensions;
 use Illuminate\Validation\Rules\Enum;
 use Illuminate\Validation\Rules\Password;
@@ -739,6 +740,16 @@ class RuleTest extends TestCase
             'date invalid' => [
                 'data' => 'a',
                 'rules' => fn() => RuleSet::create()->date(),
+                'fails' => true,
+            ],
+            'date fluent valid' => [
+                'data' => '2025-01-02',
+                'rules' => fn() => RuleSet::create()->date(fn(Date $rule) => $rule->before('2025-01-03')->after('2025-01-01')),
+                'fails' => false,
+            ],
+            'date fluent invalid' => [
+                'data' => '2025-01-04',
+                'rules' => fn() => RuleSet::create()->date(fn(Date $rule) => $rule->before('2025-01-03')->after('2025-01-01')),
                 'fails' => true,
             ],
             'dateEquals valid' => [

--- a/tests/Unit/RuleTest.php
+++ b/tests/Unit/RuleTest.php
@@ -21,6 +21,7 @@ use Illuminate\Validation\Rules\Date;
 use Illuminate\Validation\Rules\Dimensions;
 use Illuminate\Validation\Rules\Email;
 use Illuminate\Validation\Rules\Enum;
+use Illuminate\Validation\Rules\File as FileRule;
 use Illuminate\Validation\Rules\Password;
 use PHPUnit\Framework\Attributes\DataProvider;
 use Sourcetoad\RuleHelper\Rule;
@@ -1201,6 +1202,16 @@ class RuleTest extends TestCase
             'file invalid' => [
                 'data' => 'not a file',
                 'rules' => fn() => RuleSet::create()->file(),
+                'fails' => true,
+            ],
+            'file fluent valid' => [
+                'data' => fn() => $this->mockFile('/code/image.jpg'),
+                'rules' => fn() => RuleSet::create()->file(fn(FileRule $rule) => $rule->extensions('jpg')),
+                'fails' => false,
+            ],
+            'file fluent invalid' => [
+                'data' => fn() => $this->mockFile('/code/document.docx'),
+                'rules' => fn() => RuleSet::create()->file(fn(FileRule $rule) => $rule->extensions('jpg')),
                 'fails' => true,
             ],
             'filled valid' => [


### PR DESCRIPTION
Switch minimum supported Laravel to 12.x and switch `date`, `email`, `file`, and `image` rules to fluent rule configuration pattern.